### PR TITLE
Get the release tag for jade

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function(grunt) {
   grunt.loadTasks("backbone.marionette/tasks");
 
   grunt.config.merge({
-    'gitty:latestTag': {
+    'gitty:releaseTag': {
       marionette: {
         options: {
           repo: 'backbone.marionette'
@@ -88,7 +88,7 @@ module.exports = function(grunt) {
       },
       pages: {
         files: "src/**/*.jade",
-        tasks: ['notify:preHTML', 'jade', 'notify:postHTML']
+        tasks: ['notify:preHTML', 'compile-templates', 'notify:postHTML']
       }
     },
 
@@ -98,8 +98,10 @@ module.exports = function(grunt) {
           "dist/index.html": "src/index.jade"
         },
         options: {
-          data: {
-            VERSION: grunt.option("VERSION") || "V.X.X.X"
+          data: function(){
+            return{
+              VERSION: global.releaseTag || "V.X.X.X"
+            };
           }
         }
       }
@@ -166,15 +168,20 @@ module.exports = function(grunt) {
   grunt.registerTask('compile-site', [
     'sass',
     'copy',
-    'jade',
+    'compile-templates',
     'postcss'
+  ]);
+
+  grunt.registerTask('compile-templates', [
+    'gitty:releaseTag',
+    'jade'
   ]);
 
   grunt.registerTask('compile-docs', [
     'compileDocs',
     'sass',
     'copy',
-    'gitty:latestTag'
+    'gitty:releaseTag'
   ]);
 
   grunt.registerTask('compile-api', [
@@ -183,7 +190,7 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('compile-docco', [
-    'gitty:latestTag:marionette',
+    'gitty:releaseTag:marionette',
     'docco:build'
   ]);
 

--- a/tasks/gitty.js
+++ b/tasks/gitty.js
@@ -2,24 +2,57 @@ var _       = require('underscore');
 var path    = require('path');
 var gitty   = require('gitty');
 var Promise = require('bluebird');
+var semver  = require('semver');
+
+var remapInvalidTag = function(tag) {
+  if (tag == 'v0.4.1a') {
+    tag = 'v0.4.1-a';
+  } else if (tag == 'v1.7') {
+    tag = 'v1.7.0';
+  } else if (tag == 'v1.4.0beta') {
+    tag = 'v1.4.0-beta';
+  }
+
+  return tag;
+};
+
+var sortTags = function(tags) {
+  return tags.sort(function(v1, v2) {
+    return semver.rcompare(remapInvalidTag(v1), remapInvalidTag(v2));
+  });
+};
 
 module.exports = function(grunt) {
-  grunt.registerMultiTask('gitty:latestTag', function() {
+  grunt.registerMultiTask('gitty:releaseTag', function() {
     var options = this.options();
     var done = this.async();
     var repo = Promise.promisifyAll(gitty(path.resolve(options.repo)));
 
-    repo.tagsAsync()
-    .then(function(tags) {
-      var lastTag = _.last(tags);
+    Promise.bind(this)
+      .then(function() {
+        var cliTag = grunt.option('TAG');
 
-      return repo.checkoutAsync(lastTag).then(function() {
-        return lastTag;
+        if(cliTag){
+          global.releaseTag = cliTag;
+        }
+
+        if(global.releaseTag){
+          return global.releaseTag;
+        }
+        return repo.tagsAsync()
+          .then(sortTags)
+          .then(function(tags) {
+            global.releaseTag = _.first(tags);
+            return global.releaseTag;
+          })
+      }).then(function(tag) {
+        return repo.checkoutAsync(tag).then(function() {
+          return tag;
+        });
       })
-    })
-    .then(function(lastTag) {
-      grunt.log.ok('Latest Tag Checked out! -- ' + lastTag);
-      done();
-    });
+      .then(function(tag) {
+        grunt.log.ok('Tag Checked out! -- ' + tag);
+        done();
+      });
   });
 };


### PR DESCRIPTION
Resolved https://github.com/marionettejs/marionettejs.com/issues/25

Allow for cli -TAG=v.X.X.X to override the latest tag.
Cache tag on a global

Possible refactors:
- Cache sorted tags
- Split up tag retrieval from the checkout and only checkout when necessary
- gitty util for tag sorting functions shared between gitty and compile-docs
