### PR TITLE
Gitty caching and tag util

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,4 +1,5 @@
 var autoprefixer = require('autoprefixer-core');
+var GittyCache = require('./tasks/utils/gitty-cache');
 
 module.exports = function(grunt) {
   require('load-grunt-tasks')(grunt);
@@ -7,8 +8,17 @@ module.exports = function(grunt) {
   grunt.loadTasks('tasks');
   grunt.loadTasks('backbone.marionette/tasks');
 
+  GittyCache.setReleaseTag(grunt.option('TAG'));
+
   grunt.config.merge({
-    'gitty:latestTag': {
+    'gitty:releaseTag': {
+      marionette: {
+        options: {
+          repo: 'backbone.marionette'
+        }
+      }
+    },
+    'gitty:checkoutTag': {
       marionette: {
         options: {
           repo: 'backbone.marionette'
@@ -88,7 +98,7 @@ module.exports = function(grunt) {
       },
       pages: {
         files: 'src/**/*.jade',
-        tasks: ['notify:preHTML', 'jade', 'notify:postHTML']
+        tasks: ['notify:preHTML', 'compile-templates', 'notify:postHTML']
       }
     },
 
@@ -98,8 +108,10 @@ module.exports = function(grunt) {
           'dist/index.html': 'src/index.jade'
         },
         options: {
-          data: {
-            VERSION: grunt.option('VERSION') || 'V.X.X.X'
+          data: function(){
+            return {
+              VERSION: GittyCache.releaseTag || 'v.X.X.X'
+            };
           }
         }
       }
@@ -156,7 +168,7 @@ module.exports = function(grunt) {
         dest : 'dist/api'
       }
     }
-  });
+});
 
   grunt.registerTask('dev', [
     'notify:watch',
@@ -166,15 +178,20 @@ module.exports = function(grunt) {
   grunt.registerTask('compile-site', [
     'sass',
     'copy',
-    'jade',
+    'compile-templates',
     'postcss'
+  ]);
+
+  grunt.registerTask('compile-templates', [
+    'gitty:releaseTag',
+    'jade'
   ]);
 
   grunt.registerTask('compile-docs', [
     'compileDocs',
     'sass',
     'copy',
-    'gitty:latestTag'
+    'gitty:checkoutTag'
   ]);
 
   grunt.registerTask('compile-api', [
@@ -183,7 +200,7 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('compile-docco', [
-    'gitty:latestTag:marionette',
+    'gitty:checkoutTag:marionette',
     'docco:build'
   ]);
 

--- a/tasks/gitty.js
+++ b/tasks/gitty.js
@@ -1,25 +1,36 @@
-var _       = require('underscore');
-var path    = require('path');
-var gitty   = require('gitty');
-var Promise = require('bluebird');
+var _        = require('underscore');
+var path     = require('path');
+var gitty    = require('gitty');
+var Promise  = require('bluebird');
+var GittyCache = require('./utils/gitty-cache');
 
 module.exports = function(grunt) {
-  grunt.registerMultiTask('gitty:latestTag', function() {
+  grunt.registerMultiTask('gitty:checkoutTag', function() {
     var options = this.options();
     var done = this.async();
     var repo = Promise.promisifyAll(gitty(path.resolve(options.repo)));
 
-    repo.tagsAsync()
-    .then(function(tags) {
-      var lastTag = _.last(tags);
-
-      return repo.checkoutAsync(lastTag).then(function() {
-        return lastTag;
+    GittyCache.getReleaseTag(repo)
+      .then(function(tag) {
+        return repo.checkoutAsync(tag).then(function() {
+          return tag;
+        });
       })
-    })
-    .then(function(lastTag) {
-      grunt.log.ok('Latest Tag Checked out! -- ' + lastTag);
-      done();
-    });
+      .then(function(tag) {
+        grunt.log.ok('Tag Checked out! -- ' + tag);
+        done();
+      });
+  });
+
+  grunt.registerMultiTask('gitty:releaseTag', function() {
+    var options = this.options();
+    var done = this.async();
+    var repo = Promise.promisifyAll(gitty(path.resolve(options.repo)));
+
+    GittyCache.getReleaseTag(repo)
+      .then(function(tag) {
+        grunt.log.ok('Release Tag! -- ' + tag);
+        done();
+      });
   });
 };

--- a/tasks/utils/gitty-cache.js
+++ b/tasks/utils/gitty-cache.js
@@ -1,0 +1,43 @@
+var _       = require('underscore');
+var gitty   = require('gitty');
+var Promise = require('bluebird');
+var sortTags = require('./tags').sort;
+
+module.exports = {
+  getSortedTags: function(repo) {
+    return Promise.bind(this)
+      .then(function() {
+
+        //return if already cached
+        if(this.sortedTags){
+          return this.sortedTags;
+        }
+
+        return repo.tagsAsync()
+          .then(sortTags)
+          .then(function(tags){
+            this.sortedTags = tags;
+            return this.sortedTags;
+          }.bind(this));
+      });
+  },
+  getReleaseTag: function(repo) {
+    return Promise.bind(this)
+      .then(function() {
+
+        //return if already cached
+        if(this.releaseTag){
+          return this.releaseTag;
+        }
+
+        return this.getSortedTags(repo)
+          .then(function(tags) {
+            this.releaseTag = _.first(tags);
+            return this.releaseTag;
+          }.bind(this));
+      });
+  },
+  setReleaseTag: function(tag) {
+    this.releaseTag = tag;
+  }
+}

--- a/tasks/utils/tags.js
+++ b/tasks/utils/tags.js
@@ -1,0 +1,28 @@
+var _      = require('underscore');
+var semver = require('semver');
+
+var remapInvalidTag = function(tag) {
+  if (tag == 'v0.4.1a') {
+    tag = 'v0.4.1-a';
+  } else if (tag == 'v1.7') {
+    tag = 'v1.7.0';
+  } else if (tag == 'v1.4.0beta') {
+    tag = 'v1.4.0-beta';
+  }
+
+  return tag;
+};
+
+module.exports = {
+  sort: function(tags) {
+    return tags.sort(function(v1, v2) {
+      return semver.rcompare(remapInvalidTag(v1), remapInvalidTag(v2));
+    });
+  },
+  valid: function(tags) {
+    return _.chain(tags)
+    .map(remapInvalidTag)
+    .filter(_.partial(semver.lte, "v0.9.0"))
+    .value();
+  }
+};


### PR DESCRIPTION
Resolved https://github.com/marionettejs/marionettejs.com/issues/25
Vastly improves https://github.com/marionettejs/marionettejs.com/pull/38

Allow for cli -TAG=v.X.X.X to override the latest tag.  
Otherwise gets and caches the latest tag on the repo.

Not thrilled with setting the exact same options for `gitty:checkoutTag` and `gitty:releaseTag` Is there a better way?
Wasn't certain of a best location for utils.
I don't think there's a way to utilize a promise for the jade data, so `git:releaseTag` must come before `jade` or you'll get `v.X.X.X` in the HTML.