### PR TITLE
/docs/current.html -> /docs/current/index.html

### DIFF
--- a/src/sections/_about.jade
+++ b/src/sections/_about.jade
@@ -11,7 +11,7 @@ section.about.column-contain
       h3 Quick Links
       ul
         li
-          a(href="docs/current.html") Docs
+          a(href="docs/current/") Docs
         li
           a(href="annotated-src/backbone.marionette.html") Annotated Source Code
         li

--- a/src/sections/_download.jade
+++ b/src/sections/_download.jade
@@ -10,7 +10,7 @@ section.column-contain.hidden-xs#download
       a(href='https://github.com/marionettejs/backbone.marionette/blob/master/changelog.md')
         | See Changelog
       span.middot ·
-      a(href='https://github.com/marionettejs/backbone.marionette/tree/master/docs')
+      a(href='docs/current/')
         | Docs
     .cl
   div.bower-install

--- a/tasks/compile-docs.js
+++ b/tasks/compile-docs.js
@@ -161,10 +161,13 @@ _.extend(Compiler.prototype, {
       // If this is the latest release ensure to write the /docs/current file
       if (files[0].tag == this.tags[0]) {
         return fs.writeFileAsync(indexPath, indexMarkup)
-        .then(function() {
-          var currentPath = path.resolve(files[0].pathname, "../", "current.html");
-          return fs.writeFileAsync(currentPath, indexMarkup);
-        });
+          .then(function() {
+            var currentPath = path.resolve(files[0].pathname, '../current/');
+            var currentIndex = path.resolve(currentPath, 'index.html');
+            return mkdirp(currentPath).bind(this).then(function() {
+                return fs.writeFileAsync(currentIndex, indexMarkup);
+              });
+          });
       }
 
       return fs.writeFileAsync(indexPath, indexMarkup);


### PR DESCRIPTION
Moving this into a directory is more like the current live site URL

And it keeps us from having to deal with the hardcoded paths ie:
`<link rel="stylesheet" href="../../styles/docs.css">`