### PR TITLE
Tell cloudflare to ignore the twitter script

### DIFF
--- a/src/sections/_social_header.jade
+++ b/src/sections/_social_header.jade
@@ -3,5 +3,5 @@
   a(href="https://gitter.im/marionettejs/backbone.marionette", class="gitter-button", target="_blank")
     img(src="images/gitter-badge.svg")
   a.twitter-follow-button(href="https://twitter.com/marionettejs", data-show-count="false") Follow @marionettejs
-  script.
+  script(data-cfasync='false').
     !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');


### PR DESCRIPTION
Can't test this locally, but I'm pretty sure this is cloudflare switching this to text/rocketscript

As @jdaudier pointed out in gitter, the twitter link is broken on http://dev.marionettejs.com/   I'm guessing this will resolve that.