### PR TITLE
fixed video slide resizing when image and youtube vid are swapped

### DIFF
--- a/src/stylesheets/marionette.scss
+++ b/src/stylesheets/marionette.scss
@@ -114,38 +114,41 @@
       list-style: none;
     }
   }
-  .vid {
-    margin-bottom: 20px;
-    border-radius: 10px;
-    width: 45%;
-    float: left;
-    position: relative;
-    .vid-screenshot {
-      height: 320px;
-      width: 100%;
-    }
-    .play {
-        background: #000 url('../images/play.png') center center no-repeat;
-        position: absolute;
-        top: 120px;
-        left: 50%;
-        margin-left: -40px;
-        display: inline-block;
-        width: 80px;
-        height: 80px;
-        cursor: pointer;
-        border-radius: 50%;
-    }
-    .fluid-width-video-wrapper {
-      margin-bottom: $small-font;
-    }
-    p {
-      font-size: $mid-font;
-      line-height: 16px;
-      font-family: $sans;
-    }
-    @include below($med-breakpoint) {
-      width: 100%;
+  .video_slide {
+    width: 100%;
+    .vid {
+      margin-bottom: 20px;
+      border-radius: 10px;
+      width: 45%;
+      float: left;
+      position: relative;
+      .vid-screenshot {
+        height: 320px;
+        width: 100%;
+      }
+      .play {
+          background: #000 url('../images/play.png') center center no-repeat;
+          position: absolute;
+          top: 120px;
+          left: 50%;
+          margin-left: -40px;
+          display: inline-block;
+          width: 80px;
+          height: 80px;
+          cursor: pointer;
+          border-radius: 50%;
+      }
+      .fluid-width-video-wrapper {
+        margin-bottom: $small-font;
+      }
+      p {
+        font-size: $mid-font;
+        line-height: 16px;
+        font-family: $sans;
+      }
+      @include below($med-breakpoint) {
+        width: 100%;
+      }
     }
   }
   figcaption {


### PR DESCRIPTION
@samccone this addresses the issue @jdaudier found with the text jumping to the left for two of the videos when you click on the screenshot and the youtube iframes are loaded