### PR TITLE
Better github href handlin

### DIFF
--- a/tasks/compile-docs.js
+++ b/tasks/compile-docs.js
@@ -18,9 +18,9 @@ var BLACKLIST_FILES = ['readme.md']
 renderer.heading = function(text, level, raw) {
   var escapedText = raw
     .toLowerCase()
-    .replace(/['\.]/g, '') // Add edge cases: /[1|2|3]/g
-    .replace(/[^\w]+/g, '-')
-    .replace(/-$/, '');
+    .replace(/['\.:]/g, '') // Add edge cases: /[1\.A]/g
+    .replace(/[^\w|$|\/]+/g, '-') // Characters not to dasherize
+    .replace(/\/|^-|-$/g, ''); // Clean up
 
   return (
     '<h'+level+'>'+


### PR DESCRIPTION
Now removes `'` `.` `:`
Now doesn't dasherize `$` `/`
Now removes `/` and leading/trailing `-`

Solves https://github.com/marionettejs/marionettejs.com/issues/72