### PR TITLE
Compress images during compile-site

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -54,7 +54,7 @@ module.exports = function(grunt) {
           {
             expand: true,
             cwd: 'src/',
-            src: ['images/**/*'],
+            src: ['images/**/*','!images/**/*.{png,jpg,gif}'],
             dest: 'dist/'
           },
           {
@@ -75,6 +75,17 @@ module.exports = function(grunt) {
             dest: 'dist/styles'
           }
         ]
+      }
+    },
+
+    imagemin: {
+      dynamic: {
+        files: [{
+          expand: true,
+          cwd: 'src/',
+          src: ['images/**/*.{png,jpg,gif}'],
+          dest: 'dist/'
+        }]
       }
     },
 
@@ -197,6 +208,7 @@ module.exports = function(grunt) {
   grunt.registerTask('compile-site', [
     'sass',
     'copy',
+    'imagemin',
     'compile-templates',
     'postcss'
   ]);
@@ -211,6 +223,7 @@ module.exports = function(grunt) {
     'compileDocs',
     'sass',
     'copy',
+    'imagemin',
     'gitty:checkoutTag'
   ]);
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-copy": "0.5.0",
+    "grunt-contrib-imagemin": "^0.9.2",
     "grunt-contrib-jade": "0.12.0",
     "grunt-contrib-watch": "0.6.1",
     "grunt-docco": "0.3.3",


### PR DESCRIPTION
Might be able to tweak the settings one way or another, but by default the images directory went from 2.4MB to 1.1MB and at first glance I don't see any noticeable quality loss.

Might solve https://github.com/marionettejs/marionettejs.com/issues/59