### PR TITLE
Minor UX fix for navigation list

### DIFF
--- a/src/stylesheets/_header.scss
+++ b/src/stylesheets/_header.scss
@@ -154,6 +154,7 @@
         color: white;
         display: inline-block;
         padding: 0 14px;
+        cursor: auto;
         
         @include below(660px) {
           display: none;


### PR DESCRIPTION
This PR fixes minor UX issue in global navigation component:
https://github.com/marionettejs/marionettejs.com/blob/master/src/stylesheets/_header.scss#L89-L215
The  `a, .left` rule is too wide:
https://github.com/marionettejs/marionettejs.com/blob/master/src/stylesheets/_header.scss#L116-L124
The  `.middot` should not appear to be interactive element. It serves as a lists separator.

Thanks!