### PR TITLE
Wrap logo within link area for better UX

### DIFF
--- a/src/docs/template.html
+++ b/src/docs/template.html
@@ -26,8 +26,8 @@
               </svg>
           </a>
         </div>
-        <a href="http://marionettejs.com">
-          <img src="../../images/marionette.svg" alt="Marionette.js – The Backbone Framework" class="primary-logo">
+        <a href="http://marionettejs.com" class="primary-logo">
+          <img src="../../images/marionette.svg" alt="Marionette.js – The Backbone Framework">
         </a>
         <div class="styled-select">
           <select id="version-dropdown">

--- a/src/stylesheets/docs.scss
+++ b/src/stylesheets/docs.scss
@@ -171,7 +171,10 @@ pre code {
     }
   }
 
-  .primary-logo{
+  .primary-logo {
+    display: block;
+  }
+  .primary-logo img {
     margin: 25px 25%;
     text-align: center;
     width: 50%;


### PR DESCRIPTION
This PR corrects brand logo area that is interactive:
From this:
![20150115222016](https://cloud.githubusercontent.com/assets/14539/5767028/f9b9efba-9d05-11e4-9d91-fad5c53ba3c2.jpg)
to this:
![20150115222422](https://cloud.githubusercontent.com/assets/14539/5767038/032711cc-9d06-11e4-9bf6-62c4db93f5ea.jpg)
I opted to move `primary-logo` out of image itself - to parent, so it works now as component. This allowed to avoid an ugly patch:
```
.docs__sidebar > a {
  ....
}
```
The actual logo dimensions are preserved.

Thanks!


