### PR TITLE
Use full NPM command name. Closes #124

### DIFF
--- a/src/sections/_download.jade
+++ b/src/sections/_download.jade
@@ -15,7 +15,7 @@ section.column-contain.hidden-xs#download
     p.code-wrap bower install marionette
   div
     h2 With npm
-    p.code-wrap npm i backbone.marionette
+    p.code-wrap npm install backbone.marionette
   .download-group
     h2 Pre-Packaged
     p These archives contain all of the files you need to get started with Marionette, including Backbone, jQuery and all other prerequisites.


### PR DESCRIPTION
The documentation should use commonly used terms expected to be known to users (as much as possible) I believe.
The shortcuts are not commonly known terms (mostly). That is idea behind this PR:

![20150116232303](https://cloud.githubusercontent.com/assets/14539/5785423/b90ef18c-9dd6-11e4-8376-35ae652938b4.jpg)

Thanks!
