### PR TITLE
[MINOR] Convert dot hover to arrow instead of I-beam

### DIFF
--- a/src/stylesheets/_header.scss
+++ b/src/stylesheets/_header.scss
@@ -154,7 +154,7 @@
         color: white;
         display: inline-block;
         padding: 0 14px;
-        cursor: auto;
+        cursor: default;
         
         @include below(660px) {
           display: none;


### PR DESCRIPTION
When you hover over the dots...
![2015-01-16_2324](https://cloud.githubusercontent.com/assets/1666031/5787682/2189122e-9dd7-11e4-9687-3f841b1ad5a6.png)

OLD
![beam](https://cloud.githubusercontent.com/assets/1666031/5787672/032a2be2-9dd7-11e4-91d4-90f492c76e4f.png)

NEW
![arrow](https://cloud.githubusercontent.com/assets/1666031/5787674/068d968e-9dd7-11e4-87fd-4c036bf88cdd.png)
