### PR TITLE
Use defer attribute on landing page script. Closes #151

### DIFF
--- a/src/layouts/layout.jade
+++ b/src/layouts/layout.jade
@@ -35,7 +35,7 @@ html(lang='en')
       include ../images/svg-sprite.svg
     block content
 
-    script(src="js/build.js?t=#{Date.now()}")
+    script(src="js/build.js?t=#{Date.now()}" defer)
     script.
       // Flattr
       (function() {


### PR DESCRIPTION
The landing page is using the single script covered by build process. Let the supporting browser defer loading this script after page has been parsed entirely - as all dependencies are compromised by this script.
All other scripts on the page are 3rd party scripts. The change applies only to landing page as documentation uses different layout.

Thanks!