### PR TITLE
Add focus state to contact links. Follow up to #160

### DIFF
--- a/src/stylesheets/_contribute.scss
+++ b/src/stylesheets/_contribute.scss
@@ -7,7 +7,8 @@
   margin: 0 0 5px 12px;
   transition: all 200ms ease;
   text-decoration: none;
-  &:hover {
+  &:hover,
+  &:focus {
     color: darken($dark-gray, 15%);
     text-decoration: underline;
   }


### PR DESCRIPTION
This is a trivial PR which is a follow up to already merged one: #160. It comes separately as it was not ticketed or discussed and has different subject.
The reason behind this PR is to let users whose devices do not show outlines (for whatever reason, custom css, etc) where they are in navigation - if they do not use hovering/pointing devices:

![focus](https://cloud.githubusercontent.com/assets/14539/5793739/93873d78-9f4f-11e4-977e-06ee811b60cf.gif)

This PR completes PR #160.

Thanks!
