### PR TITLE
Drop gh3.js code with custom implementation. Closes #164

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
     "jQuery.equalHeights": "mattbanks/jQuery.equalHeights#1.5.2",
     "google-code-prettify": "1.0.3",
     "jquery-unveil": "1.3.0",
-    "gh3": "1.0.3",
     "jquery": "2.1.3",
     "underscore": "1.6.0",
     "backbone": "1.1.2",

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -33,7 +33,6 @@ module.exports = function(grunt) {
       dist: {
         src: [
           'bower_components/jquery/dist/jquery.min.js',
-          'bower_components/gh3/gh3.js',
           'bower_components/jQuery.equalHeights/jquery.equalheights.min.js',
           'bower_components/google-code-prettify/bin/prettify.min.js',
           'bower_components/jquery-unveil/jquery.unveil.min.js',

--- a/src/js/github.js
+++ b/src/js/github.js
@@ -1,15 +1,10 @@
-;(function(git, $) {
-
-  var marionettejs = new git.User("marionettejs");
-  var starGazers = new git.Repository("backbone.marionette", marionettejs);
-
-  starGazers.fetch(function(err, res) {
-    if(err) { throw "No stars for you." }
-
-    var count = document.querySelector('.github');
-    var span = document.createElement('span');
-    span.innerHTML = res.stargazers_count + " stargazers";
-    count.appendChild(span);
+;(function($) {
+  var url = 'https://api.github.com/repos/marionettejs/backbone.marionette?callback=?';
+  $.getJSON(url)
+  .done(function (result) {
+    if(result.meta.status === 200) {
+      var stargazers = result.data.stargazers_count || '5700';
+      $('.github').text(stargazers + ' stargazers');
+    }
   });
-
-})(Gh3, jQuery);
+})(jQuery);

--- a/src/sections/_contribute.jade
+++ b/src/sections/_contribute.jade
@@ -16,7 +16,7 @@ section.support.column-contain
         a.support-link.support-link__with_icon(href= "https://github.com/marionettejs/backbone.marionette", target="_blank")
           svg.support-link-icon(width="18", height="18")
             use(xlink:href="#github-square")
-          span.support-link__label.github
+          span.support-link__label.github 5700 stargazers
         
   article.support_article
     h2 Contribute


### PR DESCRIPTION
This drops 3rd party library from web page source code:
- remove gh3.js from page
- use custom written code to fetch Marionette stargazers
As a fix it removes developer tool console error :+1: 