### PR TITLE
Fix overflowing video figure captions

### DIFF
--- a/src/stylesheets/_videos.scss
+++ b/src/stylesheets/_videos.scss
@@ -94,6 +94,9 @@
             font-size: $mid-font;
             line-height: 16px;
             font-family: $sans;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
           }
           @include below($med-breakpoint) {
             width: 100%;


### PR DESCRIPTION
Quick patch to make text eligible in some scenarios discussed in:
https://github.com/marionettejs/marionettejs.com/issues/116
It can be applied before different markup concept if implemented to support text flowing down.

before:
![20150120220157](https://cloud.githubusercontent.com/assets/14539/5826035/fc26ecf6-a0ef-11e4-87b3-6e1fa0934790.jpg)


after:
![20150120215447](https://cloud.githubusercontent.com/assets/14539/5825991/b4a4cccc-a0ef-11e4-9051-4427c9e922f2.jpg)

