### PR TITLE
Swap position of video and screencasts sections. Closes #171

### DIFF
--- a/src/index.jade
+++ b/src/index.jade
@@ -6,8 +6,8 @@ block content
   include ./sections/_about
   include ./sections/_downloads
   include ./sections/_code_samples
-  include ./sections/_screencasts
   include ./sections/_videos
+  include ./sections/_screencasts
   include ./sections/_books
   include ./sections/_contribute
   include ./sections/_stickers


### PR DESCRIPTION
The video section should get more prominent and visible position as discussed in original issues ticket. The change is trivial in code - more prominent in generated output and results:

![sections](https://cloud.githubusercontent.com/assets/14539/5946400/ad0d6f18-a735-11e4-9cae-09717be8159a.gif)

Thanks!
