### PR TITLE
Include about partial after base partial to fix specificity problem

### DIFF
--- a/src/stylesheets/marionette.scss
+++ b/src/stylesheets/marionette.scss
@@ -4,9 +4,9 @@
 @import "vendor/prettify/prettify";
 @import "vendor/prettify/marionette";
 @import "variables";
-@import "about";
 @import "animations";
 @import "base";
+@import "about";
 @import "books";
 @import "code_samples";
 @import "companies";


### PR DESCRIPTION
This PR provides correct declaration order for specificity of single selectors within page. The intent of correct order is visible in code as there is explicit declaration that resets this section base styling - that fails due to specificity (later declared wins with the same specificity):

Without this change there are subtle problems in about section:
![about](https://cloud.githubusercontent.com/assets/14539/5946679/f9de3780-a737-11e4-84ac-8771cc110262.gif)

where specificity of declarations matters:
![20150128215300](https://cloud.githubusercontent.com/assets/14539/5946704/2389f286-a738-11e4-8fb2-f29f187b2474.jpg)
![20150128215420](https://cloud.githubusercontent.com/assets/14539/5946726/4e00ba40-a738-11e4-913f-e0963b527e97.jpg)


Thanks!

