### PR TITLE
Use root-relative link instead of absolute path for logo link in docs

### DIFF
--- a/src/docs/template.html
+++ b/src/docs/template.html
@@ -26,7 +26,7 @@
               </svg>
           </a>
         </div>
-        <a href="http://marionettejs.com" class="primary-logo">
+        <a href="/" class="primary-logo">
           <img src="../../images/marionette.svg" alt="Marionette.js – The Backbone Framework">
         </a>
         <div class="styled-select">


### PR DESCRIPTION
This helps during development, when using different protocols on deployment, etc. This fixes a little development problem - instead of going back to root after clicking a logo (the only way to go back without using browser back buttons) one goes to project home page.
This PR fixes this:

![links](https://cloud.githubusercontent.com/assets/14539/5982927/ae679ffc-a8c8-11e4-8de6-e0011675e420.gif)

![links2](https://cloud.githubusercontent.com/assets/14539/5982929/b2cd576c-a8c8-11e4-975e-63fb4305e710.gif)

Thanks!

