### PR TITLE
Correct page semantics using real link with brand

### DIFF
--- a/src/sections/_header.jade
+++ b/src/sections/_header.jade
@@ -1,6 +1,6 @@
 .global-nav
   section.column-contain
-    .left.logo
+    a.left.logo(href="/")
       | Marionette
 
     .menu-icon


### PR DESCRIPTION
This PR brings back the basic feature on web page - brand root-based link on prominent page position (think readers).
After this change the brand will using common solution - while retaining its `scroll to top` functionality.

![20150130224544](https://cloud.githubusercontent.com/assets/14539/5983956/1639f482-a8d2-11e4-891a-16d7c52f6f93.jpg)
![20150130224605](https://cloud.githubusercontent.com/assets/14539/5983962/1caaff3c-a8d2-11e4-9853-203b68bcd874.jpg)

Thanks!

