### PR TITLE
Refactor hamburger menu semantics

### DIFF
--- a/src/sections/_header.jade
+++ b/src/sections/_header.jade
@@ -3,7 +3,7 @@
     .left.logo
       | Marionette
 
-    .menu-icon
+    button.menu-icon(type="button")
       svg(width="33px", height="24px")
         use(xlink:href="#hamburger")
 

--- a/src/stylesheets/_header.scss
+++ b/src/stylesheets/_header.scss
@@ -108,9 +108,16 @@
 
       @include below(660px) {
         color: #fff;
-        display: block;
+        line-height: inherit;
+        background: transparent {
+          image: none;
+        }
+        border: 0 solid transparent;
+        position: relative;
         float: right;
-        margin: 8px 20px 3px 0;
+        display: block;
+        padding: 4px 6px;
+        margin: 3px 12px 3px 0;
 
         &:hover {
           opacity: 0.8;


### PR DESCRIPTION
This PR refactors semantics of hamburger menu to use more user friendly/compliant solution (no divs - yeah) - the same as used in:
https://github.com/twbs/bootstrap/blob/master/docs/_includes/nav/main.html#L4
https://github.com/google/web-starter-kit/blob/master/app/index.html#L41

- change markup to use native button
- change style to retain original design and features

The solution was tested - except of IE. The iOS simulator was used to hunt down and fix a bug (line-height needs to be reset for buttons):

![menu](https://cloud.githubusercontent.com/assets/14539/5984604/04aa53a0-a8d8-11e4-873c-5eae1ac836e2.gif)

One can now trigger menu via any pointing device/software. 

Thanks!