### PR TITLE
Introduce data driven videos template. Closes #184

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -175,6 +175,10 @@ module.exports = function(grunt) {
         files: 'src/images/**/*',
         tasks: ['imagemin', 'copy']
       },
+      data: {
+        files: 'src/data/*.json',
+        tasks: ['notify:preHTML', 'compile-templates', 'notify:postHTML']
+      },
       pages: {
         files: 'src/**/*.jade',
         tasks: ['notify:preHTML', 'compile-templates', 'notify:postHTML']
@@ -189,7 +193,8 @@ module.exports = function(grunt) {
         options: {
           data: function(){
             return {
-              VERSION: GittyCache.releaseTag || 'v.X.X.X'
+              VERSION: GittyCache.releaseTag || 'v.X.X.X',
+              videos: grunt.file.readJSON('src/data/videos.json')
             };
           }
         }
@@ -200,6 +205,12 @@ module.exports = function(grunt) {
       watch: {
         options: {
           message: 'Watching for changes...'
+        }
+      },
+      
+      data: {
+        options: {
+          messages: 'Data .json files changed ...'
         }
       },
 

--- a/src/data/videos.json
+++ b/src/data/videos.json
@@ -1,0 +1,67 @@
+[
+
+  {
+    "thumbnail": "images/youtube/EvQnntaqVdE.jpg",
+    "title": "Marionette - The Backbone Framework",
+    "id": "EvQnntaqVdE"
+  },
+
+  {
+    "id": "7yZKsgKxziw",
+    "title": "Marionette 101",
+    "thumbnail": "images/youtube/7yZKsgKxziw.jpg"
+  },
+
+  {
+    "id": "CTr-tTwRH3o",
+    "title": "Nesting Your Views in Marionette",
+    "thumbnail": "images/youtube/CTr-tTwRH3o.jpg"
+  },
+
+  {
+    "id": "6wvAswHkarE",
+    "title": "Marionette Behaviors",
+    "thumbnail": "images/youtube/6wvAswHkarE.jpg"
+  },
+
+  {
+    "id": "2b1G3TdlQEU",
+    "title": "Backbone.Wreqr",
+    "thumbnail": "images/youtube/2b1G3TdlQEU.jpg"
+  },
+
+  {
+    "id": "jbGm3mJXh_s",
+    "title": "Backbone Under the Magnifying Glass",
+    "thumbnail": "images/youtube/jbGm3mJXh_s.jpg",
+    "link": {
+      "url": "https://chrome.google.com/webstore/detail/marionette-inspector/fbgfjlockdhidoaempmjcddibjklhpka?hl=en",
+      "title": "Marionette Inspector"
+    }
+  },
+
+  {
+    "id": "75d0odmbu38",
+    "title": "Using DevTools for Marionette Debugging",
+    "thumbnail": "images/youtube/75d0odmbu38.jpg"
+  },
+
+  {
+    "id": "qWr7x9wk6_c",
+    "title": "Brian Mann talks about building applications with Marionette",
+    "thumbnail": "images/youtube/qWr7x9wk6_c.jpg"
+  },
+
+  {
+    "id": "0o2whtCJw8I",
+    "title": "Unsuck Your Backbone",
+    "thumbnail": "images/youtube/0o2whtCJw8I.jpg"
+  },
+
+  {
+    "id": "VERQEr-bVTs",
+    "title": "From jQuery to Backbone/Marionette",
+    "thumbnail": "images/youtube/VERQEr-bVTs.jpg"
+  }
+
+]

--- a/src/sections/_videos.jade
+++ b/src/sections/_videos.jade
@@ -8,75 +8,15 @@ section.featured_videos.column-contain
       span
         i.fa.fa-angle-right
     .video_slideshow("data-cycle-slides" = ".video_slide")
-      .video_slide
-        figure.vid
-          div.vid-player(style="background-image:url(images/youtube/EvQnntaqVdE.jpg)",  data-vid-id="EvQnntaqVdE")
-            svg.youtube-play
-              use(xlink:href="#play")
-          p.
-            Marionette - The Backbone Framework
-      .video_slide
-        figure.vid
-          div.vid-player(style="background-image:url(images/youtube/7yZKsgKxziw.jpg)",  data-vid-id="7yZKsgKxziw")
-            svg.youtube-play
-              use(xlink:href="#play")
-          p.
-            Marionette 101
-      .video_slide
-        figure.vid
-          div.vid-player(style="background-image:url(images/youtube/CTr-tTwRH3o.jpg)",  data-vid-id="CTr-tTwRH3o")
-            svg.youtube-play
-              use(xlink:href="#play")
-          p.
-            Nesting Your Views in Marionette
-      .video_slide
-        figure.vid
-          div.vid-player(style="background-image:url(images/youtube/6wvAswHkarE.jpg)",  data-vid-id="6wvAswHkarE")
-            svg.youtube-play
-              use(xlink:href="#play")
-          p.
-            Marionette Behaviors
-      .video_slide
-        figure.vid
-          div.vid-player(style="background-image:url(images/youtube/2b1G3TdlQEU.jpg)",  data-vid-id="2b1G3TdlQEU")
-            svg.youtube-play
-              use(xlink:href="#play")
-          p.
-            Backbone.Wreqr
-      .video_slide
-        figure.vid
-          div.vid-player(style="background-image:url(images/youtube/jbGm3mJXh_s.jpg)",  data-vid-id="jbGm3mJXh_s")
-            svg.youtube-play
-              use(xlink:href="#play")
-          p Backbone Under the Magnifying Glass (
-            a(href= "https://chrome.google.com/webstore/detail/marionette-inspector/fbgfjlockdhidoaempmjcddibjklhpka?hl=en", target="_blank") Marionette Inspector
-            | )
-      .video_slide
-        figure.vid
-          div.vid-player(style="background-image:url(images/youtube/75d0odmbu38.jpg)",  data-vid-id="75d0odmbu38")
-            svg.youtube-play
-              use(xlink:href="#play")
-          p.
-            Using DevTools for Marionette Debugging
-      .video_slide
-        figure.vid
-          div.vid-player(style="background-image:url(images/youtube/qWr7x9wk6_c.jpg)",  data-vid-id="qWr7x9wk6_c")
-            svg.youtube-play
-              use(xlink:href="#play")
-          p.
-            Brian Mann talks about building applications with Marionette
-      .video_slide
-        figure.vid
-          div.vid-player(style="background-image:url(images/youtube/0o2whtCJw8I.jpg)",  data-vid-id="0o2whtCJw8I")
-            svg.youtube-play
-              use(xlink:href="#play")
-          p.
-            Unsuck Your Backbone
-      .video_slide
-        figure.vid
-          div.vid-player(style="background-image:url(images/youtube/VERQEr-bVTs.jpg)",  data-vid-id="VERQEr-bVTs")
-            svg.youtube-play
-              use(xlink:href="#play")
-          p.
-            From jQuery to Backbone/Marionette
+      each video in videos
+        .video_slide
+          figure.vid
+            div.vid-player(style="background-image:url(#{video.thumbnail})", data-vid-id="#{video.id}")
+              svg.youtube-play
+                use(xlink:href="#play")
+            p #{video.title}
+              if video.link
+                |  (
+                a(href="#{video.link.url}", target="_blank") #{video.link.title}
+                |)
   .cl


### PR DESCRIPTION
This PR introduces data driven videos section template. The purpose of this PR is to:
- simplify development (smaller template written in Jade - less errors)
- simplify maintenance like adding new content, reordering, typo fixes, etc
- make other changes less tedious (e.g. add additional markup to integrate with search engines via meta tags)

The changes:
- store information about videos in JSON data file
- modify Grunt task to use data source files for Jade templates
- add dedicated watch task to watch for changes in data files
- refactor videos template to use data at compile time

The names of attributes in `videos.json` file are based on YouTube JavaScript/JSONP naming conventions:
https://developers.google.com/youtube/2.0/developers_guide_jsonc
while embedded external `link` uses Markdown/Wiki naming convention:
http://daringfireball.net/projects/markdown/syntax#link
(a link has an url and a title - though MediaWiki uses `a name` also instead of `a title`).
```JSON
"id": "...",
"title": "...",
"thumbnail": "...",
"link": {
  "url": "...",
  "title": "..."
}
```

The generated output is exactly the same as prior this PR (10 videos within section) with exactly the same markup.

Thanks!
