### PR TITLE
Fix NPM development dependencies order

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gitty": "samccone/gitty",
     "grunt": "0.4.5",
     "grunt-contrib-clean": "0.6.0",
+    "grunt-contrib-concat": "0.5.0",
     "grunt-contrib-connect": "0.9.0",
     "grunt-contrib-copy": "0.5.0",
     "grunt-contrib-imagemin": "0.9.2",
@@ -53,7 +54,6 @@
     "marked": "0.3.2",
     "mkdirp": "0.5.0",
     "semver": "4.2.0",
-    "underscore": "1.6.0",
-    "grunt-contrib-concat": "0.5.0"
+    "underscore": "1.6.0"
   }
 }


### PR DESCRIPTION
This is trivial, maintence PR as it just swaps some lines in `package.json`.
This will stops reordering list when adding another dependency via NPM.
For example: I'm working on some feature that requires adding new dev dependency:
```
npm install --save-dev grunt-browser-sync
```
without this change adding dependency will introduce side changes:
```diff
diff --git a/package.json b/package.json
index f211148..c53a841 100644
--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "dox": "0.6.1",
     "gitty": "samccone/gitty",
     "grunt": "0.4.5",
+    "grunt-browser-sync": "^1.9.1",
     "grunt-contrib-clean": "0.6.0",
+    "grunt-contrib-concat": "0.5.0",
     "grunt-contrib-connect": "0.9.0",
     "grunt-contrib-copy": "0.5.0",
     "grunt-contrib-imagemin": "0.9.2",
@@ -53,7 +55,6 @@
     "marked": "0.3.2",
     "mkdirp": "0.5.0",
     "semver": "4.2.0",
-    "underscore": "1.6.0",
-    "grunt-contrib-concat": "0.5.0"
+    "underscore": "1.6.0"
   }
 }
```
after this PR the NPM will add only expected change:
```diff
diff --git a/package.json b/package.json
index 6480ea5..c53a841 100644
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "dox": "0.6.1",
     "gitty": "samccone/gitty",
     "grunt": "0.4.5",
+    "grunt-browser-sync": "^1.9.1",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-concat": "0.5.0",
     "grunt-contrib-connect": "0.9.0",
```
Thanks!