### PR TITLE
Show correct notification when CSS changes

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -165,7 +165,7 @@ module.exports = function(grunt) {
       },
       styles: {
         files: 'src/stylesheets/**/*.scss',
-        tasks: ['notify:preHTML', 'sass:dev', 'postcss:dev', 'notify:postHTML']
+        tasks: ['notify:preCSS', 'sass:dev', 'postcss:dev', 'notify:postCSS']
       },
       scripts: {
         files: 'src/js/**/*',


### PR DESCRIPTION
This is trivial, maintenance PR:
We used preHTML and postHTML for CSS related compilation which
was probably due to a simple omission or the copy and paste curse

This PR brings back intended notifications I think:

![css](https://cloud.githubusercontent.com/assets/14539/6009896/816f53c4-ab2e-11e4-8598-0abac3aef9eb.gif)