### PR TITLE
Use data driven books template

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -194,6 +194,7 @@ module.exports = function(grunt) {
           data: function(){
             return {
               VERSION: GittyCache.releaseTag || 'v.X.X.X',
+              books: grunt.file.readJSON('src/data/books.json'),
               videos: grunt.file.readJSON('src/data/videos.json')
             };
           }

--- a/src/data/books.json
+++ b/src/data/books.json
@@ -1,0 +1,45 @@
+[
+
+  {
+    "thumbnail": "images/books/better-bb-apps.png",
+    "title": "Better Backbone Applications with MarionetteJS",
+    "url": "https://shop.smashingmagazine.com/better-backbone-applications-with-marionettejs.html"
+  },
+
+  {
+    "thumbnail": "images/books/gentle-intro.png",
+    "title": "Backbone.Marionette.js: A Gentle Introduction",
+    "url": "https://leanpub.com/marionette-gentle-introduction?utm_campaign=marionette-gentle-introduction&utm_medium=embed&utm_source=marionettejs.com"
+  },
+
+  {
+    "thumbnail": "images/books/requirejs.png",
+    "title": "Structuring Backbone Code with RequireJS and Marionette Modules",
+    "url": "https://leanpub.com/structuring-backbone-with-requirejs-and-marionette?utm_campaign=structuring-backbone-with-requirejs-and-marionette&utm_medium=embed&utm_source=marionettejs.com"
+  },
+
+  {
+    "thumbnail": "images/books/serious-progression.png",
+    "title": "Backbone.Marionette.js: A Serious Progression",
+    "url": "https://leanpub.com/marionette-serious-progression?utm_campaign=marionette-serious-progression&utm_medium=embed&utm_source=marionettejs.com"
+  },
+
+  {
+    "thumbnail": "images/books/getting-started.png",
+    "title": "Getting Started with Backbone Marionette",
+    "url": "http://www.amazon.com/Getting-Backbone-Marionette-Raymundo-Armendariz/dp/1783284250/ref=tmm_pap_title_0?ie=UTF8&qid=1420202176&sr=1-1"
+  },
+
+  {
+    "thumbnail": "images/books/expose.png",
+    "title": "Marionette Exposé",
+    "url": "https://leanpub.com/marionetteexpose?utm_campaign=marionetteexpose&utm_medium=embed&utm_source=marionettejs.com"
+  },
+
+  {
+    "thumbnail": "images/books/bb-plugins.png",
+    "title": "Building Backbone Plugins",
+    "url": "https://leanpub.com/building-backbone-plugins?utm_campaign=building-backbone-plugins&utm_medium=embed&utm_source=marionettejs.com"
+  }
+
+]

--- a/src/sections/_books.jade
+++ b/src/sections/_books.jade
@@ -1,18 +1,6 @@
 section.books.column-contain
   h2 Books
   .book-list
-    a(href = "https://shop.smashingmagazine.com/better-backbone-applications-with-marionettejs.html", target= "_blank")
-      img(src="images/books/better-bb-apps.png", alt="Better Backbone Applications with MarionetteJS")
-    a(href = "https://leanpub.com/marionette-gentle-introduction?utm_campaign=marionette-gentle-introduction&utm_medium=embed&utm_source=marionettejs.com", target= "_blank")
-      img(src="images/books/gentle-intro.png", alt="Backbone.Marionette.js: A Gentle Introduction")
-    a(href = "https://leanpub.com/structuring-backbone-with-requirejs-and-marionette?utm_campaign=structuring-backbone-with-requirejs-and-marionette&utm_medium=embed&utm_source=marionettejs.com", target= "_blank")
-      img(src="images/books/requirejs.png", alt="Structuring Backbone Code with RequireJS and Marionette Modules")
-    a(href = "https://leanpub.com/marionette-serious-progression?utm_campaign=marionette-serious-progression&utm_medium=embed&utm_source=marionettejs.com", target= "_blank")
-      img(src="images/books/serious-progression.png", alt="Backbone.Marionette.js: A Serious Progression")
-    a(href = "http://www.amazon.com/Getting-Backbone-Marionette-Raymundo-Armendariz/dp/1783284250/ref=tmm_pap_title_0?ie=UTF8&qid=1420202176&sr=1-1", target= "_blank")
-      img(src="images/books/getting-started.png", alt="Getting Started with Backbone Marionette")
-    a(href = "https://leanpub.com/marionetteexpose?utm_campaign=marionetteexpose&utm_medium=embed&utm_source=marionettejs.com", target= "_blank")
-      img(src="images/books/expose.png", alt="Marionette Exposé")
-    a(href = "https://leanpub.com/building-backbone-plugins?utm_campaign=building-backbone-plugins&utm_medium=embed&utm_source=marionettejs.com", target= "_blank")
-      img(src="images/books/bb-plugins.png", alt="Building Backbone Plugins")
-
+    each book in books
+      a(href="#{book.url}", target="_blank")
+        img(src="#{book.thumbnail}", alt="#{book.title}")


### PR DESCRIPTION
This PR is a follow up to ticket discussing data driven templates:
https://github.com/marionettejs/marionettejs.com/issues/184
and previous - already merged PR:
https://github.com/marionettejs/marionettejs.com/pull/185

This PR introduces similar changes as in #185 and:
- adds JSON file for books information
- modifies Grunt file to use data during compile
- refactors books template file to use data

The changes introduced by PR should have no side effect and does not change rendering context, order or markup.

The reasoning behind this PR is similar to #185: simplify future development and maintenance. 

```diff
commit bc37f111f5aa61cbdf3d9973389075a46b779084
Author: Peter Blazejewicz <peter.blazejewicz@gmail.com>
Date:   Sun Feb 1 21:11:28 2015 +0100

    Use data driven books template
    - add JSON file for books information
    - modify Grunt file to use data during compile
    - refactor books template file to use data

 gruntfile.js             |  1 +
 src/data/books.json      | 45 +++++++++++++++++++++++++++++++++++++++++++++
 src/sections/_books.jade | 18 +++---------------
 3 files changed, 49 insertions(+), 15 deletions(-)
```

Tested locally and side-by-side with hosted version (peer review)
Thanks!