### PR TITLE
Refactor/companies markup

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -74,7 +74,7 @@ $(document).ready(function() {
       var $this = $(this);
 
       e.preventDefault();
-      $this.parent().toggleClass('active');
+      $this.toggleClass('active');
       $('.slider').toggleClass('closed');
 
       var txt = $this.text() === 'more'? 'less': 'more';

--- a/src/sections/_companies.jade
+++ b/src/sections/_companies.jade
@@ -37,9 +37,10 @@ section.logos.column-contain.hidden-xs
     li
       a(href= "http://weebly.com", target="_blank")
         img(data-src="images/logos/weebly.png", alt= "Weebly")
-    div
-      a(href="#", class="show-more") more
-    .slider.closed
+  div
+    a(href="#", class="show-more") more
+  .slider.closed
+    ul.company-logo-list  
       li
         a(href= "http://advanseez.com", target="_blank")
           img(data-src="images/logos/advanseez.png", alt= "Advanseez", class="adjust")

--- a/src/stylesheets/_companies.scss
+++ b/src/stylesheets/_companies.scss
@@ -23,18 +23,19 @@
   }
 }
 
-.show-more:after {
-  content: "[+]";
-  font-weight: bold;
-  letter-spacing: 2px;
-  opacity: 0.7;
-  font-size: 0.7em;
-  padding-left: 5px;
-  display: inline-block;
-}
-
-.active .show-more:after {
-  content: "[-]";
+.show-more {
+  &:after {
+    content: "[+]";
+    font-weight: bold;
+    letter-spacing: 2px;
+    opacity: 0.7;
+    font-size: 0.7em;
+    padding-left: 5px;
+    display: inline-block;
+  }
+  &.active:after {
+    content: "[-]";
+  }
 }
 
 /* Pure CSS slide up & down: http://davidwalsh.name/css-slide */


### PR DESCRIPTION
This PR fixes two different problems with markup:
- the list is constructed with incorrectly placed elements 
- the link (interactive element) is better suited to be `active` - as there is no tab elements to use `div` as in tabs
(and we have shorter selector which is a win)

Visually there won't be a difference. There will be a difference for browsers that corrects markup on-the-fly, validators and screen readers.
For example from this:
![20150204223514](https://cloud.githubusercontent.com/assets/14539/6050253/558d8014-acbe-11e4-92ac-75126539ead4.jpg)

![20150204223630](https://cloud.githubusercontent.com/assets/14539/6050257/5c7a4df8-acbe-11e4-9026-de4c7e548708.jpg)

There are no visual changes (unless unintended - but I've tested this)
Thanks!



