### PR TITLE
Space clickable area of links evenly. Fixes #197

### DIFF
--- a/src/stylesheets/docs.scss
+++ b/src/stylesheets/docs.scss
@@ -142,11 +142,11 @@ pre code {
   }
 
   nav {
-    margin: 27px 0 45px;
+    margin: 20px 0 45px;
     a {
       display: block;
       font-size: 0.8em;
-      padding: 0px 26% 15px;
+      padding: 7px 26% 8px;
 
       &:hover, &.is-selected{
         color: $red;


### PR DESCRIPTION
Small fix for better UX:
- a link has the same vertical padding now
- change nav margin to offset links vertical padding changes

No visual change :)

before:
![navigation](https://cloud.githubusercontent.com/assets/14539/6088177/f4c1d3d8-ae53-11e4-832b-bd13cd117edf.gif)

after:
![20150206225034](https://cloud.githubusercontent.com/assets/14539/6088182/00722656-ae54-11e4-8b12-8a1474cb3d6c.jpg)

