### PR TITLE
Refactor markup in header and navigation section of page

### DIFF
--- a/src/sections/_footer.jade
+++ b/src/sections/_footer.jade
@@ -3,4 +3,4 @@ footer
     span.heart-icon &hearts;
     | by&nbsp;
     a(href="https://github.com/marionettejs/marionettejs.com/graphs/contributors", target="_blank") all of us
-  a(href="#0", class="top") Top
+  a(href="#top", class="top") Top

--- a/src/sections/_header.jade
+++ b/src/sections/_header.jade
@@ -1,4 +1,4 @@
-.global-nav
+header.global-nav
   section.column-contain
     a.left.logo(href="/")
       | Marionette

--- a/src/sections/_header.jade
+++ b/src/sections/_header.jade
@@ -6,29 +6,29 @@ header.global-nav
     button.menu-icon(type="button")
       svg(width="33px", height="24px")
         use(xlink:href="#hamburger")
-
-    ul.right.nav-slider.closed
-      li.left
-        a(href="docs/current") Docs
-        span.middot ·
-      li.left
-        a(href="annotated-src/backbone.marionette.html") Annotated Source
-        span.middot ·
-      li.left
-        a(href="https://gitter.im/marionettejs/backbone.marionette", target="_blank") Support
-        span.middot ·
-      li.left
-        a(href="http://blog.marionettejs.com") Blog
-        span.middot ·
-      li.left
-        a.twitter(href="https://twitter.com/marionettejs", target="_blank")
-          svg.support-link-icon(width="18", height="16")
-            use(xlink:href="#twitter")
-        span.middot ·
-      li.left
-        a.github-mark(href="https://github.com/marionettejs/backbone.marionette", target="_blank")
-          svg(width="19px", height="19px")
-            use(xlink:href="#github-mark")
+    nav.nav-slider.closed(role="navigation")
+      ul.nav-slider__list
+        li.left
+          a(href="docs/current") Docs
+          span.middot ·
+        li.left
+          a(href="annotated-src/backbone.marionette.html") Annotated Source
+          span.middot ·
+        li.left
+          a(href="https://gitter.im/marionettejs/backbone.marionette", target="_blank") Support
+          span.middot ·
+        li.left
+          a(href="http://blog.marionettejs.com") Blog
+          span.middot ·
+        li.left
+          a.twitter(href="https://twitter.com/marionettejs", target="_blank")
+            svg.support-link-icon(width="18", height="16")
+              use(xlink:href="#twitter")
+          span.middot ·
+        li.left
+          a.github-mark(href="https://github.com/marionettejs/backbone.marionette", target="_blank")
+            svg(width="19px", height="19px")
+              use(xlink:href="#github-mark")
     .clear
 
 .masthead

--- a/src/sections/_header.jade
+++ b/src/sections/_header.jade
@@ -1,5 +1,5 @@
 header.global-nav
-  section.column-contain
+  .global-nav__section.column-contain
     a.left.logo(href="/")
       | Marionette
 

--- a/src/stylesheets/_base.scss
+++ b/src/stylesheets/_base.scss
@@ -97,3 +97,16 @@ ul {
     display: none;
   }
 }
+
+// screen readers only
+// h5pb: http://git.io/byNN
+.hidden-visually {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}

--- a/src/stylesheets/_header.scss
+++ b/src/stylesheets/_header.scss
@@ -99,7 +99,7 @@
   width: 100%;
   z-index: 999;
 
-  section {
+  &__section {
     padding: 0;
     border: none;
 
@@ -131,6 +131,7 @@
       line-height: 40px;
 
       &:hover {
+        color: white;
         cursor: pointer;
       }
     }

--- a/src/stylesheets/_header.scss
+++ b/src/stylesheets/_header.scss
@@ -145,6 +145,16 @@
     }
 
     .nav-slider {
+      float: right;
+      
+      &__list {
+        float: left;  
+        > li {
+          position: relative;
+          display: block;
+        }  
+      }
+      
       @include below(660px) {
         background-color: $red;
         float: none;
@@ -157,6 +167,10 @@
         transition-duration: .5s;
         transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
         -webkit-transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
+        
+        &__list {
+          float: none;
+        }
       }
     }
 
@@ -183,6 +197,7 @@
         float: none;
         text-align: center;
         border-top: 1px dashed lighten($red, 15%);
+        box-sizing: content-box;
         font-size: $mid-font;
 
         a {

--- a/src/stylesheets/_header.scss
+++ b/src/stylesheets/_header.scss
@@ -93,7 +93,7 @@
 
 .global-nav {
   background: $red;
-  height: 40px;
+  min-height: 40px;
   position:fixed;
   top:0;
   width: 100%;
@@ -129,6 +129,7 @@
       color: white;
       text-decoration: none;
       line-height: 40px;
+      height: 40px;
 
       &:hover {
         color: white;


### PR DESCRIPTION
This is a set of small commits that:
- adds fallback to use `#top` HTML5 anchor 
- introduces use of `header` tag in header section (HTML5)
- replaces `section` tag within `header` tag with `div` which which is better suited to be used as container. This commit introduces subcomponent to global navigation `__section` to work around dependency in existing code on explicit tag names
- fixes a problem - visible only on Firefox browsers - with global navigation heights:  
![navbar](https://cloud.githubusercontent.com/assets/14539/6093588/7981abb4-af05-11e4-812d-d951c9e97ab1.gif)
- introduces `nav` element as standalone container for navigation elements. This change requires refactoring existing stylesheet code as `ul` list is no longer top container here - it is just a navigation subcomponent (similar solution is used e.g. in Bootstrap: 
https://github.com/twbs/bootstrap/blob/master/less/navs.less#L1-L69
- introduces helper class to hide text from page - while retaining it to readers, robots, etc. I can be used later to refactor existing menus, for example to hide or show text context on screen conditionally via media queries breakpoints:  
![20150207195237](https://cloud.githubusercontent.com/assets/14539/6093599/1e944602-af06-11e4-83c7-54fba23bb935.jpg)

The commits should not introduce any visible change to existing page (though not verified on IE yet).

If required I could split this into separate PRs.

Thanks!
