### PR TITLE
Start a second page

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -188,7 +188,8 @@ module.exports = function(grunt) {
     jade: {
       compile : {
         files: {
-          'dist/index.html': 'src/index.jade'
+          'dist/index.html': 'src/index.jade',
+          'dist/projects.html': 'src/projects.jade'
         },
         options: {
           data: function(){

--- a/src/common/_global_nav.jade
+++ b/src/common/_global_nav.jade
@@ -1,0 +1,32 @@
+.global-nav
+  section.column-contain
+    a.left.logo(href="/")
+      | Marionette
+
+    button.menu-icon(type="button")
+      svg(width="33px", height="24px")
+        use(xlink:href="#hamburger")
+
+    ul.right.nav-slider.closed
+      li.left
+        a(href="docs/current") Docs
+        span.middot ·
+      li.left
+        a(href="annotated-src/backbone.marionette.html") Annotated Source
+        span.middot ·
+      li.left
+        a(href="https://gitter.im/marionettejs/backbone.marionette", target="_blank") Support
+        span.middot ·
+      li.left
+        a(href="http://blog.marionettejs.com") Blog
+        span.middot ·
+      li.left
+        a.twitter(href="https://twitter.com/marionettejs", target="_blank")
+          svg.support-link-icon(width="18", height="16")
+            use(xlink:href="#twitter")
+        span.middot ·
+      li.left
+        a.github-mark(href="https://github.com/marionettejs/backbone.marionette", target="_blank")
+          svg(width="19px", height="19px")
+            use(xlink:href="#github-mark")
+    .clear

--- a/src/projects.jade
+++ b/src/projects.jade
@@ -1,0 +1,9 @@
+extends layouts/layout
+
+block content
+  include ./projects/_header
+
+  h1.
+    heya
+
+  include ./sections/_footer

--- a/src/projects/_header.jade
+++ b/src/projects/_header.jade
@@ -1,0 +1,9 @@
+include ../common/_global_nav
+
+.masthead
+  .wrapper
+    .left
+      img(src="images/marionette.svg", alt="Marionette.js – A scalable and composite application architecture for Backbone.js", class= "primary-logo")
+    .right
+      h1 Hand Picked Community Projects
+      h2 Here's a list of projects we personally like that you might be able to draw inspiration from.

--- a/src/sections/_header.jade
+++ b/src/sections/_header.jade
@@ -1,35 +1,4 @@
-.global-nav
-  section.column-contain
-    a.left.logo(href="/")
-      | Marionette
-
-    button.menu-icon(type="button")
-      svg(width="33px", height="24px")
-        use(xlink:href="#hamburger")
-
-    ul.right.nav-slider.closed
-      li.left
-        a(href="docs/current") Docs
-        span.middot ·
-      li.left
-        a(href="annotated-src/backbone.marionette.html") Annotated Source
-        span.middot ·
-      li.left
-        a(href="https://gitter.im/marionettejs/backbone.marionette", target="_blank") Support
-        span.middot ·
-      li.left
-        a(href="http://blog.marionettejs.com") Blog
-        span.middot ·
-      li.left
-        a.twitter(href="https://twitter.com/marionettejs", target="_blank")
-          svg.support-link-icon(width="18", height="16")
-            use(xlink:href="#twitter")
-        span.middot ·
-      li.left
-        a.github-mark(href="https://github.com/marionettejs/backbone.marionette", target="_blank")
-          svg(width="19px", height="19px")
-            use(xlink:href="#github-mark")
-    .clear
+include ../common/_global_nav
 
 .masthead
   .wrapper


### PR DESCRIPTION
I started working on a projects page a month or so ago... Instead of letting this work go dormant on my local branch for perpetuity, I decided to push it to this PR. I think sam is interested in working on a projects page, but more importantly It'll be nice to have a template for additional pages that share the nav and footer. I could see us move some of the home page content over for example. 