### PR TITLE
Markup small changes and corrections

### DIFF
--- a/src/sections/_footer.jade
+++ b/src/sections/_footer.jade
@@ -1,6 +1,4 @@
 footer
-  p Made with
-    span.heart-icon &hearts;
-    | by&nbsp;
+  p Made with &hearts; by&nbsp;
     a(href="https://github.com/marionettejs/marionettejs.com/graphs/contributors", target="_blank") all of us
   a(href="#top", class="top") Top

--- a/src/sections/_header.jade
+++ b/src/sections/_header.jade
@@ -35,7 +35,7 @@ header.global-nav
   .wrapper
     .left
       img(src="images/marionette.svg", alt="Marionette logo", class= "primary-logo")
-      img(src="images/marionette-text.svg", alt="Marionette", class= "logo-text")
+      img(src="images/marionette-text.svg", alt="Marionette.js", class= "logo-text")
     .right
       h1 The Backbone Framework
       h2 Marionette simplifies your Backbone application code with robust views and architecture solutions.

--- a/src/sections/_screencasts.jade
+++ b/src/sections/_screencasts.jade
@@ -4,14 +4,14 @@ section.screencasts.column-contain
   ul
     li
       a.link(href="http://www.pluralsight.com/courses/marionette-fundamentals", target= "_blank")
-        img.screencast-thumb.left(src="images/screenshots/pluralsight.png", alt='pluralsight')
+        img.screencast-thumb.left(src="images/screenshots/pluralsight.png", alt='')
       .copy.right
         a.link(href="http://www.pluralsight.com/courses/marionette-fundamentals", target= "_blank") Marionette Fundamentals by Pluralsight
         p.description.
           This paid course provides an in-depth look at Marionette with four hours of quality content. It is one of the more recently released screencasts.
     li
       a.link(href="http://BackboneRails.com", target= "_blank")
-        img.screencast-thumb.left(src="images/screenshots/backbonerails.png", alt='backbone rails')
+        img.screencast-thumb.left(src="images/screenshots/backbonerails.png", alt='')
       .copy.right
         a.link(href="http://BackboneRails.com", target= "_blank") BackboneRails
         p.description
@@ -20,7 +20,7 @@ section.screencasts.column-contain
 
     li
       a.link(href="https://code.tutsplus.com/courses/advanced-backbone-patterns-and-techniques", target= "_blank")
-        img.screencast-thumb.left(src="images/screenshots/introductiontomarionette.png", alt='introduction to marionette')
+        img.screencast-thumb.left(src="images/screenshots/introductiontomarionette.png", alt='')
       .copy.right
         a.link(href="https://code.tutsplus.com/courses/advanced-backbone-patterns-and-techniques", target= "_blank") Tuts+ Introduction to Marionette
         p.description

--- a/src/sections/_stickers.jade
+++ b/src/sections/_stickers.jade
@@ -3,7 +3,7 @@ section.stickers.column-contain
     a(href = "http://devswag.com/products/marionette-stickers-4", target= "_blank")
       img.stickers(src="images/stickers.png", alt="Marionette sticker")
     a(href = "http://devswag.com/products/marionette-stickers-4", target= "_blank")
-      img(src="images/stickers-laptop.png", alt="Marionette sticker")
+      img(src="images/stickers-laptop.png", alt="Marionette sticker on a MacBook laptop")
   .sticker-order.right
     header
       h2 Stickers!

--- a/src/stylesheets/_footer.scss
+++ b/src/stylesheets/_footer.scss
@@ -26,7 +26,6 @@ footer {
   }
 
   .heart-icon {
-    margin: 0 3px;
     color: #b0c9d8;
   }
 }


### PR DESCRIPTION
When working on previous PR these ones should go into separate PR:
- better descriptive text for alts where required (sticker on a laptop or the Marionette.js text)
- empty alt text where not required and allowed by specification (like in screencast section):
![20150208225219](https://cloud.githubusercontent.com/assets/14539/6098908/31cb9bbc-afec-11e4-8039-7a92859f864f.jpg)
- now we can copy `Made with ♥ by all of us` from the page :)
![20150208232625](https://cloud.githubusercontent.com/assets/14539/6098914/8212b65a-afec-11e4-8644-99b2284f1dd5.jpg)

Thanks!
