### PR TITLE
Remove dead links. Closes #204

### DIFF
--- a/src/sections/_companies.jade
+++ b/src/sections/_companies.jade
@@ -129,9 +129,6 @@ section.logos.column-contain.hidden-xs
         a(href= "https://www.myedu.com", target="_blank")
           img(data-src="images/logos/myedu.png", alt= "myEdu")
       li
-        a(href= "https://www.onehealth.com", target="_blank")
-          img(data-src="images/logos/onehealth.png", alt= "OneHealth")
-      li
         a(href= "https://www.mypebble.co.uk", target="_blank")
           img(data-src="images/logos/pebble.png", alt= "Pebble")
       li
@@ -167,9 +164,6 @@ section.logos.column-contain.hidden-xs
       li
         a(href= "http://rollout.io", target="_blank")
           img(data-src="images/logos/rollout.png", alt= "Rollout", class="adjust")
-      li
-        a(href= "https://www.shopetti.com", target="_blank")
-          img(data-src="images/logos/shopetti.png", alt= "shopetti", style= "max-height:80px")
       li
         a(href= "http://www.besnappy.com", target="_blank")
           img(data-src="images/logos/snappy.png", alt= "BeSnappy")


### PR DESCRIPTION
The addresses still resolve to `host` but services behind them are dead. The links return 404 for users and crawlers.

Thanks!