### PR TITLE
Refactor/markup for improved content access

### DIFF
--- a/src/sections/_about.jade
+++ b/src/sections/_about.jade
@@ -19,7 +19,7 @@ section.about.column-contain
         li
           a(href= "http://backbonejs.org/", target= "_blank") Backbone&nbsp;
           span
-            | v1.1.x
+            | v1.1.x 
             strong.note is preferred. v1.0.0, v0.9.9 and v0.9.10 should work still.
         li
           a(href= "https://github.com/marionettejs/backbone.wreqr", target= "_blank") Backbone.Wreqr

--- a/src/sections/_downloads.jade
+++ b/src/sections/_downloads.jade
@@ -12,10 +12,10 @@ section.column-contain.hidden-xs#download
     .cl
   div.bower-install
     h2 With Bower
-    p.code-wrap bower install marionette
+    code.code-wrap bower install marionette
   div
     h2 With npm
-    p.code-wrap npm install backbone.marionette
+    code.code-wrap npm install backbone.marionette
   .download-group
     h2 Pre-Packaged
     p These archives contain all of the files you need to get started with Marionette, including Backbone, jQuery and all other prerequisites.

--- a/src/sections/_header.jade
+++ b/src/sections/_header.jade
@@ -23,11 +23,13 @@ header.global-nav
           span.middot ·
         li.left
           a.twitter(href="https://twitter.com/marionettejs", target="_blank")
+            span.hidden-visually Twitter @marionettejs
             svg.support-link-icon(width="18", height="16")
               use(xlink:href="#twitter")
           span.middot ·
         li.left
           a.github-mark(href="https://github.com/marionettejs/backbone.marionette", target="_blank")
+            span.hidden-visually GitHub @marionettejs
             svg(width="19px", height="19px")
               use(xlink:href="#github-mark")
     .clear

--- a/src/sections/_header.jade
+++ b/src/sections/_header.jade
@@ -4,6 +4,7 @@ header.global-nav
       | Marionette
 
     button.menu-icon(type="button")
+      span.hidden-visually Toggle menu
       svg(width="33px", height="24px")
         use(xlink:href="#hamburger")
     nav.nav-slider.closed(role="navigation")

--- a/src/stylesheets/_downloads.scss
+++ b/src/stylesheets/_downloads.scss
@@ -9,7 +9,8 @@
   padding:        5px 12px;
   background: rgb(252, 252, 252);
   margin-bottom: 20px;
-
+  color: #56585E;
+  line-height: 30px;
   font: {
     size:   15px;
     family: monospace;


### PR DESCRIPTION
This PR contains set of non-visual fixes and changes that are all related to textual content of web page as viewed by machine or when *naked css* is applied. The commits improves accessibility of the web site, its searchable (indexable) content. It starts to be capable  subject of machine text-to-speech translation:
Example:

![20150209230857](https://cloud.githubusercontent.com/assets/14539/6116907/b69e863c-b0b0-11e4-99e9-a475a6443512.jpg)

https://soundcloud.com/peter-blazejewicz/marionettejs-speak

Note: this is not VoiceOver/etc - this is just text-to-speach converter from screen reader/headles browser. The machine reader can see web page now as nicely laid down page of text:
https://gist.github.com/peterblazejewicz/dd6402f7254bee2e38a9

The changes:
- add text falback text to navigation toggle button

![20150209220911](https://cloud.githubusercontent.com/assets/14539/6117007/a77c20f0-b0b1-11e4-8c10-75af64166933.jpg)

- add text fallback text to navigation items:

![20150209221819](https://cloud.githubusercontent.com/assets/14539/6117010/b7657912-b0b1-11e4-938c-e4ce449db113.jpg)

- fix small missing space bug

- use `code` tag for machine code (the oh-myzsh theme is not rendering this boldly - but `code` is bluish now)

![20150209223308](https://cloud.githubusercontent.com/assets/14539/6117020/d35122f2-b0b1-11e4-9dda-96a497c2440f.jpg)

Thanks!


