### PR TITLE
Add notranslate class to skip Transifex Live translation. See #216

### DIFF
--- a/src/sections/_about.jade
+++ b/src/sections/_about.jade
@@ -11,18 +11,18 @@ section.about.column-contain
       h3 Requirements
       ul
         li
-          a(href="http://jquery.com/", target="_blank") jQuery&nbsp;
-          span v1.8+
+          a.notranslate(href="http://jquery.com/", target="_blank") jQuery&nbsp;
+          span.notranslate v1.8+
         li
-          a(href= "http://underscorejs.org/", target="_blank") Underscore&nbsp;
-          span v1.4.4+
+          a.notranslate(href= "http://underscorejs.org/", target="_blank") Underscore&nbsp;
+          span.notranslate v1.4.4+
         li
-          a(href= "http://backbonejs.org/", target= "_blank") Backbone&nbsp;
+          a.notranslate(href= "http://backbonejs.org/", target= "_blank") Backbone&nbsp;
           span
             | v1.1.x 
             strong.note is preferred. v1.0.0, v0.9.9 and v0.9.10 should work still.
         li
-          a(href= "https://github.com/marionettejs/backbone.wreqr", target= "_blank") Backbone.Wreqr
+          a.notranslate(href= "https://github.com/marionettejs/backbone.wreqr", target= "_blank") Backbone.Wreqr
         li
-          a(href= "https://github.com/marionettejs/backbone.babysitter", target= "_blank") Backbone.BabySitter
+          a.notranslate(href= "https://github.com/marionettejs/backbone.babysitter", target= "_blank") Backbone.BabySitter
   .cl

--- a/src/sections/_code_samples.jade
+++ b/src/sections/_code_samples.jade
@@ -2,7 +2,7 @@ section.code-samples.column-contain.hidden-xs
   .code-sample-block.first-sample-block
       h4.code-header Define view classes
       pre.prettyprint
-        code.
+        code.notranslate.
           var SingleLink = Marionette.ItemView.extend({
             tagName: "li",
             template: _.template("&lt;a href='&lt;%-path%>'>&lt;%-path%>&lt;/a>")
@@ -16,7 +16,7 @@ section.code-samples.column-contain.hidden-xs
   .code-sample-block.second-sample-block
     h4.code-header Pass in data
     pre.prettyprint
-      code.
+      code.notranslate.
         var list = new Backbone.Collection([
           {path: 'http://google.com'},
           {path: 'http://mojotech.com'},
@@ -32,8 +32,8 @@ section.code-samples.column-contain.hidden-xs
     .result
       ul
         li
-          a(href="http://google.com", target="_blank") http://google.com
+          a.notranslate(href="http://google.com", target="_blank") http://google.com
         li
-          a(href="http://mojotech.com", target="_blank") http://mojotech.com
+          a.notranslate(href="http://mojotech.com", target="_blank") http://mojotech.com
     .cl
   .cl

--- a/src/sections/_downloads.jade
+++ b/src/sections/_downloads.jade
@@ -12,30 +12,30 @@ section.column-contain.hidden-xs#download
     .cl
   div.bower-install
     h2 With Bower
-    code.code-wrap bower install marionette
+    code.code-wrap.notranslate bower install marionette
   div
     h2 With npm
-    code.code-wrap npm install backbone.marionette
+    code.code-wrap.notranslate npm install backbone.marionette
   .download-group
     h2 Pre-Packaged
     p These archives contain all of the files you need to get started with Marionette, including Backbone, jQuery and all other prerequisites.
     p These packages include the standard UMD version of both the non-minified and minified versions of Marionette.
     h3 *nix (.tar.gz)
     p
-      a(href='downloads/backbone.marionette.tar.gz') backbone.marionette.tar.gz
+      a.notranslate(href='downloads/backbone.marionette.tar.gz') backbone.marionette.tar.gz
 
     h3 Windows (.zip)
     p
-      a(href='downloads/backbone.marionette.zip') backbone.marionette.zip
+      a.notranslate(href='downloads/backbone.marionette.zip') backbone.marionette.zip
   .download-group
     h2 Bundled (UMD)
     p Download the bundled backbone.marionette.js file with the Backbone.Wreqr and Backbone.BabySitter prerequisites built in.
     .gw
       ul.g
         li
-          a(href='downloads/backbone.marionette.js') backbone.marionette.js
+          a.notranslate(href='downloads/backbone.marionette.js') backbone.marionette.js
         li
-          a(href='downloads/backbone.marionette.min.js') backbone.marionette.min.js
+          a.notranslate(href='downloads/backbone.marionette.min.js') backbone.marionette.min.js
   .download-group
     h2 Core
     p Download the core backbone.marionette.js file, without Backbone.BabySitter or Backbone.Wreqr.
@@ -44,7 +44,7 @@ section.column-contain.hidden-xs#download
     .gw
       ul.g
         li
-          a(href= 'downloads/core/backbone.marionette.js') backbone.marionette.js
+          a.notranslate(href= 'downloads/core/backbone.marionette.js') backbone.marionette.js
         li
-          a(href= 'downloads/core/backbone.marionette.min.js') backbone.marionette.min.js
+          a.notranslate(href= 'downloads/core/backbone.marionette.min.js') backbone.marionette.min.js
   .cl

--- a/src/sections/_footer.jade
+++ b/src/sections/_footer.jade
@@ -3,6 +3,6 @@ footer
     a(href="https://github.com/marionettejs/marionettejs.com/graphs/contributors", target="_blank") all of us
   p
     small Insights by 
-      a(href="//www.hotjar.com/?utm_source=badge", target="_blank") Hotjar
+      a.notranslate(href="//www.hotjar.com/?utm_source=badge", target="_blank") Hotjar
 
   a(href="#top", class="top") Top

--- a/src/sections/_header.jade
+++ b/src/sections/_header.jade
@@ -44,5 +44,5 @@ header.global-nav
       h2 Marionette simplifies your Backbone application code with robust views and architecture solutions.
       a.btn.download-button(href = "#download")
         | Download&nbsp;
-        span= VERSION
+        span.notranslate= VERSION
       a.btn.download-button.view-docs(href = "/docs/current") View Docs


### PR DESCRIPTION
Add `notranslate` class to other text content within page to skip that content from Transifex Live translation.
See #216

This covers most of filenames, version tags, code instructions and similar content that should be skipped
by Transifex translation service

Thanks!