### PR TITLE
Fix/buttons text diplay. Closes #215

### DIFF
--- a/src/stylesheets/_header.scss
+++ b/src/stylesheets/_header.scss
@@ -22,7 +22,7 @@
     max-width: 1200px;
 
     .secondary-color {
-      width: 154px;
+      min-width: 154px;
     }
 
     .left {

--- a/src/stylesheets/_ui.scss
+++ b/src/stylesheets/_ui.scss
@@ -11,10 +11,17 @@ a.btn {
   color:            white;
   height:           $button-size;
   display:          inline-block;
+  vertical-align:   middle;
   background:       $blue;
   line-height:      $button-size;
-  text-decoration:  none;
-
+  text: {
+    align: center;
+    decoration: none;
+    overflow: ellipsis;
+  }
+  word-wrap: normal;
+  white-space: nowrap;
+  overflow: hidden;
   font: {
     size:   16px;
     weight: bold;


### PR DESCRIPTION
This PR fixes some outstanding issues described in #215 that became ostensible when applying multi-language strings to current design.
Simply:
- get standard styles used to style text in link/button elements
- use min-width as advise where appropriate. Otherwise clip text if we use fixed width (and refactor later)

![20150212211316](https://cloud.githubusercontent.com/assets/14539/6176132/9a8ff2c0-b2fc-11e4-8a8a-0a5a75bf8ada.jpg)
![20150212211044](https://cloud.githubusercontent.com/assets/14539/6176133/9a93b158-b2fc-11e4-8aaa-aa6190d42fdf.jpg)
![20150212210644](https://cloud.githubusercontent.com/assets/14539/6176134/9a9730bc-b2fc-11e4-87a3-0e38c551dddd.jpg)
![20150212210630](https://cloud.githubusercontent.com/assets/14539/6176135/9a9de380-b2fc-11e4-8450-8e0eae8aedfe.jpg)
![20150212210606](https://cloud.githubusercontent.com/assets/14539/6176136/9a9ffd28-b2fc-11e4-8753-25fbc098892c.jpg)