### PR TITLE
Add favicon/apple icon to docs template. See #224

### DIFF
--- a/src/docs/template.html
+++ b/src/docs/template.html
@@ -2,7 +2,8 @@
   <head>
     <title><%- file.basename %> - Marionette.js Docs</title>
     <link rel="stylesheet" href="../../styles/docs.css?t=<%- Date.now() %>">
-
+    <link ref="shortcut icon" href="../../images/favicon.ico" type="image/x-icon">
+    <link ref="apple-touch-icon" href="../../images/apple-touch-icon.png">
     <!--Hotjar-->
     <script>
       (function(f,b){


### PR DESCRIPTION
This PR adds links to favicon/apple-touch icon to documentation template - missing as pointed in #224

Thanks!