### PR TITLE
Fixes #224

### DIFF
--- a/src/docs/template.html
+++ b/src/docs/template.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title><%- file.basename %> - Marionette.js Docs</title>
+    <title><%- file.title %> - Marionette.js Documentation</title>
     <link rel="stylesheet" href="../../styles/docs.css?t=<%- Date.now() %>">
     <link ref="shortcut icon" href="../../images/favicon.ico" type="image/x-icon">
     <link ref="apple-touch-icon" href="../../images/apple-touch-icon.png">


### PR DESCRIPTION
Not sure this is the correct fix but file.title is already available at `compile-docs.js`, see map() returned hash in `Compiler.readFiles()`