### PR TITLE
Cleanup/styles

### DIFF
--- a/src/sections/_header.jade
+++ b/src/sections/_header.jade
@@ -24,7 +24,7 @@ header.global-nav
         li.left
           a.github-mark(href="https://github.com/marionettejs/backbone.marionette", target="_blank")
             span.hidden-visually GitHub @marionettejs
-            svg(width="19px", height="19px")
+            svg.support-link-icon(width="19px", height="19px")
               use(xlink:href="#github-mark")
     .clear
 

--- a/src/stylesheets/_back_to_top_button.scss
+++ b/src/stylesheets/_back_to_top_button.scss
@@ -23,13 +23,9 @@
   visibility: hidden;
   opacity: 0;
 
-  -webkit-transition: opacity .3s 0s, visibility 0s .3s;
-  -moz-transition: opacity .3s 0s, visibility 0s .3s;
   transition: opacity .3s 0s, visibility 0s .3s;
 
   &.is-visible, &.fade-out {
-    -webkit-transition: opacity .3s 0s, visibility 0s 0s;
-    -moz-transition: opacity .3s 0s, visibility 0s 0s;
     transition: opacity .3s 0s, visibility 0s 0s;
   }
 

--- a/src/stylesheets/_base.scss
+++ b/src/stylesheets/_base.scss
@@ -71,9 +71,6 @@ p {
   }
 }
 
-.sans {
-  font-family: $sans;
-}
 pre {
   padding:    20px;
   font-size:  $small-font;

--- a/src/stylesheets/_code_samples.scss
+++ b/src/stylesheets/_code_samples.scss
@@ -1,10 +1,5 @@
 .code-samples {
-  .code-samples {
-    overflow: hidden;
-    border-right: 1px #2c3e50 solid;
-    background-color: #34495E;
-    border-radius: 5px;
-  }
+  
   .code-sample-block {
     float: left;
     width: 33%;

--- a/src/stylesheets/_contribute.scss
+++ b/src/stylesheets/_contribute.scss
@@ -17,10 +17,6 @@
     margin-left: 0;
     color: $gray;
   }
-  &__icon {
-    position: relative;
-    vertical-align: middle;
-  }
   &__label {
     margin-left: 12px;
     vertical-align: middle;

--- a/src/stylesheets/_contribute.scss
+++ b/src/stylesheets/_contribute.scss
@@ -1,5 +1,6 @@
 .support-link-icon {
-  vertical-align: text-top;
+  position: relative;
+  vertical-align: middle;
 }
 .support-link {
   color: $dark-gray;

--- a/src/stylesheets/_footer.scss
+++ b/src/stylesheets/_footer.scss
@@ -24,8 +24,4 @@ footer {
       }
     }
   }
-
-  .heart-icon {
-    color: #b0c9d8;
-  }
 }

--- a/src/stylesheets/_header.scss
+++ b/src/stylesheets/_header.scss
@@ -189,10 +189,6 @@
           height: 40px;
         }
 
-        .github-mark svg {
-          margin-top: 10px;
-        }
-
         &:hover {
           background-color: lighten($red, 10%);
         }
@@ -203,10 +199,6 @@
       &:hover {
         opacity: 0.8;
       }
-    }
-
-    .github-mark svg {
-      margin-top: 11px;
     }
 
     @include below(660px) {

--- a/src/stylesheets/_ui.scss
+++ b/src/stylesheets/_ui.scss
@@ -34,7 +34,7 @@ a.btn {
 
   border-radius: $button-size;
 
-  &.btn-action, &.social {
+  &.btn-action {
     padding: 0 20px;
     background-color: $aqua;
     color: white;
@@ -42,12 +42,7 @@ a.btn {
       background: darken($aqua, 15%);
     }
   }
-
-  &.social {
-    height: 28px;
-    line-height: 29px;
-    padding: 0 10px;
-  }
+  
 }
 
 .btn-action {
@@ -80,16 +75,4 @@ a.btn {
 
 .section-header {
   margin-bottom: $center_pad;
-}
-
-.headline {
-  color:        $gray;
-  margin:       0;
-  text-align:   center;
-  line-height:  26px;
-
-  font: {
-    size:   $large-font;
-    weight: bold;
-  }
 }

--- a/src/stylesheets/_videos.scss
+++ b/src/stylesheets/_videos.scss
@@ -57,8 +57,6 @@
           position: relative;
           .vid-player {
             background-size: cover;
-            -moz-background-size: cover;
-            -webkit-background-size: cover;
             background-position: center;
             background-repeat: no-repeat;
             height: 320px;

--- a/src/stylesheets/_videos.scss
+++ b/src/stylesheets/_videos.scss
@@ -6,13 +6,7 @@
     margin-top: 10px;
     margin-bottom: 0;
   }
-  header {
-    position: relative;
-    ul {
-      padding-left: 0;
-      list-style: none;
-    }
-  }
+
   .video_slideshow_scroller {
     overflow: hidden;
 
@@ -87,9 +81,7 @@
               color: $red;
             }
           }
-          .fluid-width-video-wrapper {
-            margin-bottom: $small-font;
-          }
+
           p {
             font-size: $mid-font;
             line-height: 16px;


### PR DESCRIPTION
This PR removes unused or invalid styles to save download size (in fact most of them are simply reported by CSS auditing tools - something discussed with @samccone today).
Another gain is improved rendering of svg icons after these changes.
Thanks!

cc/ @jdaudier can you review these changes pleas? I've made sure that I've not removed declarations that are used by JavaScript (like less/more [+], etc).