### PR TITLE
Add micro data for Marionette Inspector

### DIFF
--- a/src/sections/_inspector.jade
+++ b/src/sections/_inspector.jade
@@ -1,15 +1,15 @@
-section.screencasts.inspector.column-contain
-  h2 Marionette Inspector - Chrome Extension
+section.screencasts.inspector.column-contain(itemscope, itemtype="http://schema.org/WebApplication")
+  h2(itemprop="name") Marionette Inspector - Chrome Extension
 
   ul
     li
       .col-2-3
-        a.link(href="http://chrome.google.com/webstore/detail/marionette-inspector/fbgfjlockdhidoaempmjcddibjklhpka", target= "_blank")
-          img.thumbnail.left(src="images/screenshots/inspector-screenshots.gif", alt="Marionette Inspector")
+        a.link(itemprop="url", href="http://chrome.google.com/webstore/detail/marionette-inspector/fbgfjlockdhidoaempmjcddibjklhpka", target= "_blank")
+          img.thumbnail.left(itemprop="image", src="images/screenshots/inspector-screenshots.gif", alt="Marionette Inspector")
 
       .col-1-3.right
-        p.description.
+        p.description(itemprop="description").
           A world-class inspector for exploring your application's views, models, events and more. You won't know how you got by without it.
 
-        a.btn.btn-action(href="http://chrome.google.com/webstore/detail/marionette-inspector/fbgfjlockdhidoaempmjcddibjklhpka", target="_blank") Install Now
+        a.btn.btn-action(itemprop="downloadUrl", href="http://chrome.google.com/webstore/detail/marionette-inspector/fbgfjlockdhidoaempmjcddibjklhpka", target="_blank") Install Now
         a.btn.btn-action.secondary-color(href = "http://youtu.be/jbGm3mJXh_s", target= "_blank") Watch Video


### PR DESCRIPTION
Add WebApplication micro data based on Google Chrome Web store
micro data used by Google to describe Inspector
(minus ratings and other dynamic data)

This PR is intended to improve Inspector indexing cababilities - it already has very good indexing and reachability via Google.
This PR adds following semantics:
```
webapplication
itemType = http://schema.org/WebApplication
name = Marionette Inspector - Chrome Extension
url = http://chrome.google.com/webstore/detail/marionette-inspector/fbgfjlockdhidoaempmjcddibjklhpka
image
href = images/screenshots/inspector-screenshots.gif
text = Marionette Inspector
description = A world-class inspector for exploring your application's views, models, events and more. You won't know how you got by without it.
downloadurl
href = http://chrome.google.com/webstore/detail/marionette-inspector/fbgfjlockdhidoaempmjcddibjklhpka
text = Install Now
```