### PR TITLE
Add robots.txt to web site project. Closes #255

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -104,6 +104,16 @@ module.exports = function(grunt) {
             dest: 'dist'
           }
         ]
+      },
+      main: {
+        files: [
+          {
+            cwd: 'src/',
+            expand: true,
+            src: ['robots.txt'],
+            dest: 'dist/'
+          }
+        ]
       }
     },
 

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,0 +1,7 @@
+# www.robotstxt.org/
+# Allow crawling of all content except of some directories
+User-agent: *
+Disallow: /bower_components/
+Disallow: /downloads/
+Disallow: /js/
+Disallow: /styles/


### PR DESCRIPTION
This PR introduces `robots.txt` required by Twitter to validate (approve) our TwitterCard as explained #255 - the `robots.txt` are also used by crawlers - so this will be helpful.

- add robots.txt file
- add Grunt task target to include in dist

In the future we could add `humans.txt` btw:
http://humanstxt.org/
https://github.com/h5bp/html5-boilerplate/blob/master/src/humans.txt

Thanks!
