### PR TITLE
Add Download page

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -214,7 +214,9 @@ module.exports = function(grunt) {
       compile : {
         files: {
           'dist/index.html': 'src/index.jade',
-          'dist/inspector/index.html': 'src/inspector/index.jade'
+          'dist/inspector/index.html': 'src/inspector/index.jade',
+          'dist/download/index.html': 'src/download/index.jade'
+
         },
         options: {
           data: function(){

--- a/src/download/index.jade
+++ b/src/download/index.jade
@@ -1,0 +1,7 @@
+extends ../layouts/layout
+
+block content
+  include ./sections/_header
+  include ./sections/_downloads
+  include ./sections/_package_info
+

--- a/src/download/sections/_downloads.jade
+++ b/src/download/sections/_downloads.jade
@@ -12,9 +12,4 @@ section.column-contain.hidden-xs#download
   div.col-1-3.left
     h2 With npm
     code.code-wrap.notranslate npm install backbone.marionette
-
-  div.col-1-3.left
-    h2 More Information
-    p Packages and requirement &nbsp;
-      a(href="download") details.
   .cl

--- a/src/download/sections/_header.jade
+++ b/src/download/sections/_header.jade
@@ -1,0 +1,13 @@
+include ../../sections/_nav
+.masthead
+  .wrapper
+    .left
+      //- we inline svg by using data:image
+      //- keep clean markup in development by includes
+      include ../../partials/_marionette_logo
+      include ../../partials/_marionette_text
+    .right
+      h1(itemprop="alternativeHeadline") Download Information
+      br
+      p(itemprop="description") Packages and Requirements
+    .cl

--- a/src/download/sections/_package_info.jade
+++ b/src/download/sections/_package_info.jade
@@ -1,0 +1,36 @@
+section.column-contain.hidden-xs#more-information
+  .section-header
+    h2.left More Information
+    .cl
+
+  .download-group
+    h2 Pre-Packaged
+    p These archives contain all of the files you need to get started with Marionette, including Backbone, jQuery and all other prerequisites.
+    p These packages include the standard UMD version of both the non-minified and minified versions of Marionette.
+    h3 *nix (.tar.gz)
+    p
+      a.notranslate(href='downloads/backbone.marionette.tar.gz') backbone.marionette.tar.gz
+
+    h3 Windows (.zip)
+    p
+      a.notranslate(href='downloads/backbone.marionette.zip') backbone.marionette.zip
+  .download-group
+    h2 Bundled (UMD)
+    p Download the bundled backbone.marionette.js file with the Backbone.Wreqr and Backbone.BabySitter prerequisites built in.
+    .gw
+      ul.g
+        li
+          a.notranslate(href='downloads/backbone.marionette.js') backbone.marionette.js
+        li
+          a.notranslate(href='downloads/backbone.marionette.min.js') backbone.marionette.min.js
+  .download-group
+    h2 Core
+    p Download the core backbone.marionette.js file, without Backbone.BabySitter or Backbone.Wreqr.
+    p These pre-requisites are still required for Marionette to run, but this allows you to download them separately and update them independently.
+    h3 Standard .js (UMD)
+    .gw
+      ul.g
+        li
+          a.notranslate(href= 'downloads/core/backbone.marionette.js') backbone.marionette.js
+        li
+          a.notranslate(href= 'downloads/core/backbone.marionette.min.js') backbone.marionette.min.js

--- a/src/layouts/layout.jade
+++ b/src/layouts/layout.jade
@@ -61,7 +61,7 @@ html(lang='en', itemscope, itemtype="http://schema.org/WebPage")
       include ../images/svg-sprite.svg
     block content
     script(src="//cdn.transifex.com/live.js" defer)
-    link(rel='stylesheet', href='styles/marionette.css?t=#{Date.now()}')
+    link(rel='stylesheet', href='/styles/marionette.css?t=#{Date.now()}')
     script(src="js/build.js?t=#{Date.now()}" defer)
     script.
       // Google Analytics

--- a/src/sections/_header.jade
+++ b/src/sections/_header.jade
@@ -1,37 +1,8 @@
-header.global-nav
-  .global-nav__section.column-contain
-    a.left.logo(href="/")
-      | Marionette
-
-    button.menu-icon(type="button")
-      span.hidden-visually Toggle menu
-      svg(width="33px", height="24px")
-        use(xlink:href="#hamburger")
-    nav.nav-slider.closed(role="navigation")
-      ul.nav-slider__list
-        li.left
-          a(itemprop="significantLink", href="docs/current") Docs
-          span.middot ·
-        li.left
-          a(itemprop="significantLink", href="annotated-src/backbone.marionette.html") Annotated Source
-          span.middot ·
-        li.left
-          a(itemprop="relatedLink", href="https://gitter.im/marionettejs/backbone.marionette", target="_blank") Support
-          span.middot ·
-        li.left
-          a(itemprop="relatedLink", href="http://blog.marionettejs.com") Blog
-          span.middot ·
-        li.left
-          a.github-mark(itemprop="sameAs", href="https://github.com/marionettejs/backbone.marionette", target="_blank")
-            span.hidden-visually GitHub @marionettejs
-            svg.support-link-icon(width="19px", height="19px")
-              use(xlink:href="#github-mark")
-    .clear
-
+include ../sections/_nav
 .masthead
   .wrapper
     .left
-      //- we inline svg by using data:image 
+      //- we inline svg by using data:image
       //- keep clean markup in development by includes
       include ../partials/_marionette_logo
       include ../partials/_marionette_text

--- a/src/sections/_nav.jade
+++ b/src/sections/_nav.jade
@@ -1,0 +1,29 @@
+header.global-nav
+  .global-nav__section.column-contain
+    a.left.logo(href="/")
+      | Marionette
+
+    button.menu-icon(type="button")
+      span.hidden-visually Toggle menu
+      svg(width="33px", height="24px")
+        use(xlink:href="#hamburger")
+    nav.nav-slider.closed(role="navigation")
+      ul.nav-slider__list
+        li.left
+          a(itemprop="significantLink", href="docs/current") Docs
+          span.middot ·
+        li.left
+          a(itemprop="significantLink", href="annotated-src/backbone.marionette.html") Annotated Source
+          span.middot ·
+        li.left
+          a(itemprop="relatedLink", href="https://gitter.im/marionettejs/backbone.marionette", target="_blank") Support
+          span.middot ·
+        li.left
+          a(itemprop="relatedLink", href="http://blog.marionettejs.com") Blog
+          span.middot ·
+        li.left
+          a.github-mark(itemprop="sameAs", href="https://github.com/marionettejs/backbone.marionette", target="_blank")
+            span.hidden-visually GitHub @marionettejs
+            svg.support-link-icon(width="19px", height="19px")
+              use(xlink:href="#github-mark")
+    .clear


### PR DESCRIPTION
We show a ton of information in the download section that
we can move to another page.

This also gives us more opportunity to describe how we think
people can require in Marionette as we move to a more modular system.

## Reduced Download Section
![](http://f.cl.ly/items/3Y0U2u3x3p2T2F3x1J1l/Image%202015-02-17%20at%2012.25.37%20PM.png)

##  New Page
![](http://f.cl.ly/items/2o2e132b2t2k2z2A1j1t/Image%202015-02-17%20at%2012.25.27%20PM.png)

## BtDubs
This is a great example of how we can make lots more pages that help make the homepage simpler and give more details where needed