### PR TITLE
Place favicon.ico in the root directory. Fixes #268

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -89,7 +89,7 @@ module.exports = function(grunt) {
           {
             expand: true,
             cwd: 'src/',
-            src: ['images/**/*','!images/**/*.{png,jpg,gif}'],
+            src: ['images/**/*','!images/**/*.{png,jpg,gif,ico}'],
             dest: 'dist/'
           },
           {
@@ -112,7 +112,13 @@ module.exports = function(grunt) {
             expand: true,
             src: ['robots.txt'],
             dest: 'dist/'
-          }
+          },
+          {
+            cwd: 'src/images/',
+            expand: true,
+            src: ['favicon.ico'],
+            dest: 'dist/'
+          },
         ]
       }
     },

--- a/src/api/class.hbs
+++ b/src/api/class.hbs
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <!-- Place favicon.ico in the root directory: see http://git.io/Ak0N -->
     <link rel="stylesheet" href="../styles/api.css">
   </head>
   <body>

--- a/src/docs/template.html
+++ b/src/docs/template.html
@@ -2,7 +2,7 @@
   <head>
     <title><%- file.title %> - Marionette.js Documentation</title>
     <link rel="stylesheet" href="../../styles/docs.css?t=<%- Date.now() %>">
-    <link ref="shortcut icon" href="../../images/favicon.ico" type="image/x-icon">
+    <!-- Place favicon.ico in the root directory: see http://git.io/Ak0N -->
     <link ref="apple-touch-icon" href="../../images/apple-touch-icon.png">
     <!--Hotjar-->
     <script>

--- a/src/layouts/inspector-layout.jade
+++ b/src/layouts/inspector-layout.jade
@@ -19,6 +19,7 @@ html(lang='en')
     meta(property='og:url', content='http://marionettejs.com')
     meta(property='og:title', content='The Marionette Inspector')
     meta(property='og:description', content="The inspector makes it possible to understand how your App works, without needing to understand how all the code works. This is possible because everything's one click away")
+    //- Place favicon.ico in the root directory: see http://git.io/Ak0N  
     link(href='http://fonts.googleapis.com/css?family=Open+Sans', rel='stylesheet', type='text/css')
     // Hotjar
     script.

--- a/src/layouts/layout.jade
+++ b/src/layouts/layout.jade
@@ -28,7 +28,7 @@ html(lang='en', itemscope, itemtype="http://schema.org/WebPage")
     meta(property='og:see_also', content='https://github.com/marionettejs/backbone.marionette')
     meta(property='og:title', content='The Backbone Framework')
     meta(property='og:type', content='website')
-    link(rel='shortcut icon', href='images/favicon.ico', type='image/x-icon')
+    //- Place favicon.ico in the root directory: see http://git.io/Ak0N
     link(rel='apple-touch-icon', href='images/apple-touch-icon.png')
     link(href='http://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css')
 


### PR DESCRIPTION
This PR changes how favicon.ico is implemented - we just use now H5PB best practise - just place .ico at the root and avoid relative paths (with dynamic website we would render path at server with helpers):
- rewrite copy assets tag to exclude .ico
- add .ico copy task to non-assets copy target
- remove references to favicon link tag
- update all templates to point how favicon is implemented
One favicon to rule them all: see http://git.io/Ak0N

Thanks!