### PR TITLE
Add missing Inspetor properties

### DIFF
--- a/src/sections/_inspector.jade
+++ b/src/sections/_inspector.jade
@@ -1,6 +1,7 @@
 section.screencasts.inspector.column-contain(itemscope, itemtype="http://schema.org/WebApplication")
   h2(itemprop="name") Marionette Inspector - Chrome Extension
-
+  meta(itemprop="operatingSystem", content="Chrome")
+  meta(itemprop="applicationCategory", content="Developer Tools")
   ul
     li
       .col-2-3


### PR DESCRIPTION
This PR fixes a bug (missing operating system) and adds category of Inspector:

- 'operating system' is required
- 'application category' better describes its purpose

Values based on Inspector home page within Google Web Store

after:
```
name:	Marionette Inspector - Chrome Extension
operatingSystem:	Chrome
applicationCategory:	Developer Tools
url:	http://chrome.google.com/webstore/detail/marionette-inspector/fbgfjlockdhidoaempmjcddibjklhpka
image:	http://www.example.com/images/screenshots/inspector-screenshots.gif
description:	A world-class inspector for exploring your application's views, models, events and more. You won't know how you got by without it.
downloadUrl:	http://chrome.google.com/webstore/detail/marionette-inspector/fbgfjlockdhidoaempmjcddibjklhpka
```