### PR TITLE
Introduce native navigation for videos. Closes #279

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -28,22 +28,23 @@ $(document).ready(function() {
             $slideshowNext[pos !== slideCount - 1 ? 'show' : 'hide']();
         }
 
-        function addClickEffects(node) {
-            var $button = $(node).children();
-
-            $button.addClass('cbutton--click');
+        function addClickEffects(button) {
+            var $span = $(button).children('span');
+            $span.addClass('cbutton--click');
             setTimeout(function() {
-                $button.removeClass('cbutton--click');
+                $span.removeClass('cbutton--click');
             }, 500);
         }
 
-        function slideshowPrev() {
+        function slideshowPrev(event) {
+            event.preventDefault();
             pos = (pos === 0) ? pos : pos - 1;
             setTransform();
             addClickEffects(this);
         }
 
-        function slideshowNext() {
+        function slideshowNext(event) {
+            event.preventDefault();
             pos = (pos === slideCount - 1) ? pos : pos + 1;
             setTransform();
             addClickEffects(this);

--- a/src/sections/_videos.jade
+++ b/src/sections/_videos.jade
@@ -1,12 +1,10 @@
 section.featured_videos.column-contain
   h2 Videos
   .video_slideshow_scroller
-    .prev
+    a.prev(role="button", href="#")
       span.cbutton--effect
         i.fa.fa-angle-left
-    .next
-      span.cbutton--effect
-        i.fa.fa-angle-right
+        span.hidden-visually Previous video
     .video_slideshow("data-cycle-slides" = ".video_slide")
       each video in videos
         .video_slide
@@ -28,4 +26,8 @@ section.featured_videos.column-contain
                 |  (
                 a(href="#{video.link.url}", target="_blank") #{video.link.title}
                 |)
+    a.next(role="button", href="#")
+      span.cbutton--effect
+        i.fa.fa-angle-right
+        span.hidden-visually Next video
   .cl

--- a/src/stylesheets/_videos.scss
+++ b/src/stylesheets/_videos.scss
@@ -11,7 +11,6 @@
     overflow: hidden;
 
     .prev, .next {
-      display: inline-block;
       height: 50px;
       width: 50px;
       border-radius: 50%;
@@ -23,7 +22,9 @@
       line-height: 50px;
       top: 50%;
       margin-top: -25px;
-      cursor: pointer;
+      // TODO: refactor and add visual clues on
+      // :hover, :active, :focus
+      outline: none;
     }
 
     .prev {


### PR DESCRIPTION
This PR ditches non-native *mouse-only* div+span combination and introduces existing interactive elements as videos navigation:
- replace non-native elements with native navigation elements
- handle all range of user input to trigger navigation
- update section structure to reflect how content is organized
- slim down section style as native elements have these built-in
- add textual context to next and previous elements
- update client code to reflect what is a button and what is a span

By doing this we expose a range different navigation solution (mosue, keyboard, whatever) and by removing div+span noice improving the sementic of content.
```
section
  header
  previous video
  [videos ......]
  next video
```
![20150220232908](https://cloud.githubusercontent.com/assets/14539/6310749/2d0ddf14-b95a-11e4-9e9b-476fe4613f82.jpg)

See where the mouse is, I can navigate via keyboard or voice commands:
![navigation](https://cloud.githubusercontent.com/assets/14539/6310720/d23d76ee-b959-11e4-8f95-90e7d2207f2d.gif)

Thanks!

TODO: (via other ticket) add focus/active/hover states to current style
