### PR TITLE
Remove scroll effect from logo/brand. Closes #270

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -139,6 +139,4 @@ $(document).ready(function() {
 
     $backToTopBtn.on('click', scrollToTop);
 
-    $logo = $('.left.logo');
-    $logo.on('click', scrollToTop);
 });


### PR DESCRIPTION
After this commit there will be consistent UX pattern for Marionette
logo/brand on top/left corner always pointing to home page

The subject and 'whys` are discussed in #270 

Thanks!