### PR TITLE
Refactor back top top style details

### DIFF
--- a/src/sections/_footer.jade
+++ b/src/sections/_footer.jade
@@ -5,4 +5,5 @@ footer
     small Insights by 
       a.notranslate(href="//www.hotjar.com/?utm_source=badge", target="_blank") Hotjar
 
-  a(href="#top", class="top") Top
+  a(href="#top", class="top")
+    span.hidden-visually Top

--- a/src/stylesheets/_back_to_top_button.scss
+++ b/src/stylesheets/_back_to_top_button.scss
@@ -1,23 +1,21 @@
 /* Modified version of http://codyhouse.co/gem/back-to-top */
+// minimum tap area iOS (Android is even bigger)
+$back-to-top-size-small: 44px;
+$back-to-top-size-large: 50px;
+// minimum padding from screen edge
+$back-to-top-padding-small: 15px;
 
 .top {
-  display: inline-block;
-  height: 40px;
-  width: 40px;
-  border-radius: 50%;
+  height: $back-to-top-size-small;
+  width: $back-to-top-size-small;
 
   position: fixed;
-  bottom: 40px;
-  right: 10px;
-
+  bottom: 38px;
+  right: $back-to-top-padding-small;
+  z-index: $zindex-back-to-top;
+  
   box-shadow: 0 0 10px rgba(#000, .05);
-  z-index: 900;
-
-  /* image replacement properties */
-  overflow: hidden;
-  text-indent: 100%;
-  white-space: nowrap;
-
+  border-radius: 50%;
   background: rgba($med-gray, .8) url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="%23fff" d="M8 2.8l8 7.9-2.4 2.4-5.5-5.5-5.6 5.6L0 10.7z"/></svg>') no-repeat center 50%;
 
   visibility: hidden;
@@ -38,15 +36,10 @@
     opacity: .5;
   }
 
-  @media only screen and (min-width: $med-breakpoint) {
-    right: 20px;
-    bottom: 20px;
-  }
-
   @media only screen and (min-width: $large-breakpoint) {
-    height: 50px;
-    width: 50px;
+    height: $back-to-top-size-large;
+    width: $back-to-top-size-large;
     right: 30px;
-    bottom: 30px;
+    bottom: 35px;
   }
 }

--- a/src/stylesheets/_variables.scss
+++ b/src/stylesheets/_variables.scss
@@ -28,3 +28,6 @@ $xlarge-font: 30px;
 
 $col-1-3: 33%;
 $col-2-3: 66%;
+
+// z-index
+$zindex-back-to-top: 900;


### PR DESCRIPTION
This PR shave some output code, improves development and:

- apply hidden text via existing helper class (so text is within markup but no longer visible directly)
- remove declarations that are no longer required to hide text (as our text is now hidden we don't need another declarations specifically for this element and its text)
- change location of z-index value to future proof indexing (element z-index is now constant in global variables)
- apply minimum padding from screen edge (useful on mobiles - to not tap on this accidentally)
- apply minimum tap target area (using iOS as reference - to help tap on this when intended by user)
- remove middle breakpoint as not useful with new tap size (the height of element is now nearly the same as in large breakpoint - there is no real difference in medium breakpoint - like on iPad)
- position element according to height of bottom most design element (as it ends within footer - which has constant height applied)

@jdaudier mind reviewing?

Thanks!