### PR TITLE
Add section headlines to main page.

### DIFF
--- a/src/sections/_about.jade
+++ b/src/sections/_about.jade
@@ -1,21 +1,22 @@
 section.about.column-contain
   .features
+    h2 Marionette Features
     .feature.col-1-3.left
       header
-        h2 Layouts
+        h3 Layouts
       p.description.
         Organize your app in terms of small Views. Marionette makes it easy to compose rich layouts out of small components
 
     .feature.col-1-3.left
       header
-        h2 Lists
+        h3 Lists
       p.description.
         Show a sorted filtered list without breaking a sweat.
         Have a massive collection? Want to add or remove an item? No worries!
 
     .feature.col-1-3.left
       header
-        h2 Utilities
+        h3 Utilities
       p.description.
         Learn to love the details.
         We've added tons of features from templateHelpers, to a declarative UI hash, that will keep you from ever
@@ -25,7 +26,7 @@ section.about.column-contain
 
     .feature.col-1-3.left
       header
-        h2 Behaviors
+        h3 Behaviors
       p.description.
         Share complex UI interactions across views.
         Behaviors are like mixins, without all of the pain
@@ -33,13 +34,13 @@ section.about.column-contain
 
     .feature.col-1-3.left
       header
-        h2 Radio
+        h3 Radio
       p.description.
         Decoupled communication between your application components with a powerful messaging system
 
     .feature.col-1-3.left
       header
-        h2 Objects
+        h3 Objects
       p.description.
         Write classes with the same API as your views.
         Marionette Objects support features like extend,
@@ -49,9 +50,10 @@ section.about.column-contain
 
 section.about.why.column-contain
   .features
+    h2 Why Marionette?
     .feature.col-1-2.left
       header
-        h2 Approachable
+        h3 Approachable
       p.description.
         Confused about how something works? Read the annotated source code.
         Think of Marionette as the code you would have written
@@ -59,7 +61,7 @@ section.about.why.column-contain
 
     .feature.col-1-2.left
       header
-        h2 Community
+        h3 Community
       p.description.
         Marionette community is home to the most
         welcoming and vibrant discussions in the Backbone ecosystem.
@@ -67,14 +69,14 @@ section.about.why.column-contain
 
     .feature.col-1-2.left
       header
-        h2 Iterative
+        h3 Iterative
         p.description.
           Have a large unruly code base that you can not simply rewrite?
           Marionette can be added in pieces.
 
     .feature.col-1-2.left
       header
-        h2 Flexible
+        h3 Flexible
         p.description.
           Stop spending more time thinking about your framework
           than your app. Marionette will never get in the way

--- a/src/stylesheets/_about.scss
+++ b/src/stylesheets/_about.scss
@@ -21,8 +21,11 @@
     margin-bottom: 30px;
     color: #BFBFBF;
   }
+  h2 {
+    display: inline-block;
+    margin-bottom: 30px;
+  }
   .features {
-    margin: 20px 0px;
     .feature {
       margin: 0;
       padding-right: 20px;


### PR DESCRIPTION
This makes the page easier to read, and helps the reader to know why the
elements and blocks are grouped together. This should also benefit our
SEO by increasing the number of times marionette shows up on the page in
a h2 tag.

![screen shot 2015-02-22 at 12 17 54 pm](https://cloud.githubusercontent.com/assets/883126/6319538/6e7d0540-ba8d-11e4-9f7c-07d100bdfb0a.png)

![screen shot 2015-02-22 at 12 18 06 pm](https://cloud.githubusercontent.com/assets/883126/6319541/71345e0a-ba8d-11e4-9ca3-b949073c47be.png)
