### PR TITLE
Rewrite download section(s) markup and styles

### DIFF
--- a/src/download/sections/_downloads.jade
+++ b/src/download/sections/_downloads.jade
@@ -1,15 +1,15 @@
-section.column-contain.hidden-xs#download
-  .section-header
-    h2.left Package Managers
-    small.right
-      | &nbsp;#{VERSION}
-    .cl
+section.column-contain.download-section
+  
+  h2.section-header Download Information
+    small  #{VERSION}
+  p.description.
+    You can download Marionette either with #[i npm] or #[i bower] or as direct file download.
 
   div.col-1-3.left
-    h2 With Bower
+    h3 Install with #[i bower]
     code.code-wrap.notranslate bower install marionette
 
   div.col-1-3.left
-    h2 With npm
+    h3 Install with #[i npm]
     code.code-wrap.notranslate npm install backbone.marionette
   .cl

--- a/src/download/sections/_header.jade
+++ b/src/download/sections/_header.jade
@@ -7,7 +7,6 @@ include ../../sections/_nav
       include ../../partials/_marionette_logo
       include ../../partials/_marionette_text
     .right
-      h1(itemprop="alternativeHeadline") Download Options
-      br
-      p(itemprop="description") Get Marionette just the way you want it. We officially distribute via npm, bower, and static builds via our site.
+      h1 Download Options
+      p Get Marionette just the way you want it. We officially distribute via #[i npm], #[i bower], and static builds on this site.
     .cl

--- a/src/download/sections/_package_info.jade
+++ b/src/download/sections/_package_info.jade
@@ -1,21 +1,20 @@
 section.column-contain.hidden-xs#more-information
-  .section-header
-    h2.left Static Builds
-    .cl
+  h2.section-header Static Builds
+  .cl
 
   .download-group
-    h2 Pre-Packaged
+    h3 Pre-Packaged
     p These archives contain all of the files you need to get started with Marionette, including Backbone, jQuery and all other prerequisites.
     p These packages include the standard UMD version of both the non-minified and minified versions of Marionette.
-    h3 *nix (.tar.gz)
+    h4.h3 *nix (.tar.gz)
     p
       a.notranslate(href='/downloads/backbone.marionette.tar.gz') backbone.marionette.tar.gz
 
-    h3 Windows (.zip)
+    h4.h3 Windows (.zip)
     p
       a.notranslate(href='/downloads/backbone.marionette.zip') backbone.marionette.zip
   .download-group
-    h2 Bundled (UMD)
+    h3 Bundled (UMD)
     p Download the bundled backbone.marionette.js file with the Backbone.Wreqr and Backbone.BabySitter prerequisites built in.
     .gw
       ul.g
@@ -24,10 +23,10 @@ section.column-contain.hidden-xs#more-information
         li
           a.notranslate(href='/downloads/backbone.marionette.min.js') backbone.marionette.min.js
   .download-group
-    h2 Core
+    h3 Core
     p Download the core backbone.marionette.js file, without Backbone.BabySitter or Backbone.Wreqr.
     p These pre-requisites are still required for Marionette to run, but this allows you to download them separately and update them independently.
-    h3 Standard .js (UMD)
+    h4.h3 Standard .js (UMD)
     .gw
       ul.g
         li

--- a/src/sections/_downloads.jade
+++ b/src/sections/_downloads.jade
@@ -1,19 +1,19 @@
-section.column-contain.hidden-xs#download
-  .section-header
-    h2.left Download Information
-    small.right
-      | &nbsp;#{VERSION}
-    .cl
+section.column-contain.download-section#download
+
+  h2.section-header Download Information
+    small  #{VERSION}
+  p.description.
+    You can download Marionette either with #[i npm] or #[i bower] or as direct file download.
 
   div.col-1-3.left
-    h2 With bower
+    h3 Install with #[i bower]
     code.code-wrap.notranslate bower install marionette
 
   div.col-1-3.left
-    h2 With npm
+    h3 Install with #[i npm]
     code.code-wrap.notranslate npm install backbone.marionette
 
   div.col-1-3.left
-    h2 Static builds
+    h3 Static builds
     a.btn.btn-action(href="/download") Download
   .cl

--- a/src/stylesheets/_base.scss
+++ b/src/stylesheets/_base.scss
@@ -59,14 +59,18 @@ h1, h2, h3, h4, h5, h6 {
   font-family: $sans;
 }
 
-h2, h3 {
-  font-size: 24px;
+h2, h3,
+.h2, .h3 {
   line-height: 30px;
   color: $red;
   margin-bottom: 15px;
 }
 
-h3 {
+h2, .h2 {
+  font-size: 24px;
+}
+
+h3, .h3 {
   font-size: 18px;
 }
 

--- a/src/stylesheets/_downloads.scss
+++ b/src/stylesheets/_downloads.scss
@@ -59,6 +59,12 @@ small {
   font-size: 80%;
 }
 
-#download .btn-action {
-  margin-top: 0;
+.download-section {
+  small {
+    float: right;
+    color: $gray;
+  }
+  .btn-action {
+    margin-top: 0;
+  }
 }

--- a/src/stylesheets/_header.scss
+++ b/src/stylesheets/_header.scss
@@ -58,7 +58,7 @@
       }
       h1 {
         font-weight: bold;
-        margin-top: 20px;
+        margin-top: 30px;
         font-size: $xlarge-font;
       }
       p {


### PR DESCRIPTION
- improve markup - shave and trim elements - use small inside of headers for
example - which is more natural and better controller in reponsive pages
- download section is now linked in 2 distinct ways. It cannot be just hidden as
users are able to use links on any device - so the content should be visible.
Remove .hidden-xs which was OK without direct links - now it's invalid UX
- remove div.section-header - just apply .section-header directly to headers (!)
- add sectioning of content using different levels of headers h2 > h3 (> h4)
- add small copy line to download section
- add "Install ..." to describe what *with* is for
- add semantics to Bower, Npm
- remove microformats properties non-applicable yet to download page
- add util header classes to correct styling while applying correct content
sectioning (for example we use h4 headers that should look exactly the same way
as h3 headers)
- fix h2 and h3 headers font size
- DO NOT USE ID selectors in style sheets #downloads was added as target for href - that is as navigation element - add section style class to use instead
of specific id

This PR also partially fixes #298 

@jdaudier mind reviewing?