### PR TITLE
Add/basic grids

### DIFF
--- a/src/stylesheets/_base.scss
+++ b/src/stylesheets/_base.scss
@@ -31,6 +31,12 @@ section {
   max-width: 1200px;
 }
 
+//
+// WARN: DEPRECATED
+// do not work here on columns
+// please see layout/_grid.css
+// for grid system
+//
 .col-1-3 {
   width: 33.33%;
 

--- a/src/stylesheets/layout/_grid.scss
+++ b/src/stylesheets/layout/_grid.scss
@@ -1,0 +1,81 @@
+/**
+* basic grid system based on commonly used
+* container + row + columns solution using 
+* most supported spacing and clearing
+*/
+// the frequently used 25px padding/margin
+$grid-gutter-width: (2 * 25px);
+// as seen in layout max-width
+$container-max-width: $center_mw;
+
+/**
+* mixin for basic container
+*/
+@mixin base-container() {
+	margin-right: auto;
+	margin-left: auto;
+	padding-left:  ($grid-gutter-width / 2);
+	padding-right: ($grid-gutter-width / 2);
+	@include clearfix;
+}
+
+/**
+* a container with defined max width
+*/
+.container {
+	@include base-container;
+	max-width: $container-max-width;
+}
+
+/**
+* a container without defined max width
+*/
+.container-fluid {
+	@include base-container;
+}
+
+/**
+* a basic row with negative margins
+*/
+.row {
+	margin-left: -($grid-gutter-width / 2);
+	margin-right: -($grid-gutter-width / 2);
+	@include clearfix;
+}
+
+/**
+* our columns are limited now
+* and we can define them without helper functions
+* we could use [class*='col-'] in the future as well
+*/
+.col-1,
+.col-2,
+.col-3 {
+  position: relative;
+  min-height: 1px;
+  float: left;
+  padding-left:  ($grid-gutter-width / 2);
+  padding-right: ($grid-gutter-width / 2);
+}
+
+.col-1 {
+  width: 100%;
+  @include below($adaptive-snap) {
+    float: none;
+    width: auto;
+  }
+}
+.col-2 {
+  width: 66.66%;
+  @include below($adaptive-snap) {
+    float: none;
+    width: auto;
+  }
+}
+.col-3 {
+  width: 33.33%;
+  @include below($adaptive-snap) {
+    float: none;
+    width: auto;
+  }
+}

--- a/src/stylesheets/marionette.scss
+++ b/src/stylesheets/marionette.scss
@@ -8,6 +8,7 @@
 @import "utils/helpers";
 @import "animations";
 @import "base";
+@import "layout/grid";
 @import "ui";
 @import "components/buttons";
 @import "about";

--- a/src/stylesheets/marionette.scss
+++ b/src/stylesheets/marionette.scss
@@ -4,6 +4,8 @@
 @import "vendor/prettify/prettify";
 @import "vendor/prettify/marionette";
 @import "variables";
+@import "utils/mixins";
+@import "utils/helpers";
 @import "animations";
 @import "base";
 @import "ui";

--- a/src/stylesheets/utils/_helpers.scss
+++ b/src/stylesheets/utils/_helpers.scss
@@ -1,0 +1,6 @@
+/**
+* clearfix class
+*/
+.clearfix {
+  @include clearfix;
+}

--- a/src/stylesheets/utils/_mixins.scss
+++ b/src/stylesheets/utils/_mixins.scss
@@ -1,0 +1,21 @@
+/**
+* library of mixins
+*/
+
+/**
+* clearfix pattern
+* http://git.io/A9Ol
+*/
+@mixin clearfix() {
+
+  &:before,
+  &:after {
+    content: "";
+    display: table;
+  }
+
+  &:after {
+    clear: both;
+  }
+
+}


### PR DESCRIPTION
This PR adds two features related to layout:
- `clearfix` mixin and helper class
- basic grid system based on current 3 grid system (`col-1-n` - renamed to `col-n` to avoid name clashes right now).

The grid uses existing columns implementation as much as possible and implements other design decisions like commonly used padding/margins 25px as half-gutter (so gutter is 50px) and max-width of container with fixed width set to 1200px.

This source is not implemented in existing code. The `.clearfix` helper and mixin can be started using after merging, the grid system should be first used (after evaluation) for new containers and retrofitted into existing layouts to provide consistent behaviours:

![20150224221624](https://cloud.githubusercontent.com/assets/14539/6359363/d1593ae4-bc72-11e4-904c-fa1636e053cd.jpg)
![20150224222035](https://cloud.githubusercontent.com/assets/14539/6359436/78d5279c-bc73-11e4-933b-80eb673156df.jpg)
![20150224222059](https://cloud.githubusercontent.com/assets/14539/6359439/7ec94c5a-bc73-11e4-9bd6-8cb146567c98.jpg)

/cc @jdaudier please review. You can find this exact stylesheet compiled here, so you don't need to fetch this PR: http://jsbin.com/feraho