### PR TITLE
Start using blocks in main layout file

### DIFF
--- a/src/download/index.jade
+++ b/src/download/index.jade
@@ -1,5 +1,9 @@
 extends ../layouts/layout
 
+block meta
+  title(itemprop="name") Download Options | Marionette.js – The Backbone Framework
+  meta(content='Get Marionette just the way you want it.')
+
 block content
   include ./sections/_header
   include ./sections/_downloads

--- a/src/layouts/layout.jade
+++ b/src/layouts/layout.jade
@@ -12,22 +12,25 @@ html(lang='en', itemscope, itemtype="http://schema.org/WebPage")
       .
     meta(charset='utf-8')
     meta(http-equiv='X-UA-Compatible', content='IE=edge')
-    title(itemprop="name") Marionette.js – The Backbone Framework
-    meta(content='A scalable and composite application architecture.', name='description')
+    block meta
+      title(itemprop="name") Marionette.js – The Backbone Framework
+      meta(content='A scalable and composite application architecture.', name='description')
     meta(name='viewport', content='width=device-width, initial-scale=1')
-    meta(name='twitter:card', content='summary')
-    meta(name='twitter:creator', content='@marionettejs')
-    meta(name='twitter:description', content='Marionette simplifies your Backbone application code with robust views and architecture solutions.')
-    meta(name='twitter:image', content='http://marionettejs.com/images/marionette.png')
-    meta(name='twitter:site', content='@marionettejs')
-    meta(name='twitter:title', content='The Backbone Framework')
-    meta(property='og:site_name', content='Marionette.js')
-    meta(property='og:image', content='http://marionettejs.com/images/marionette.png')
-    meta(property='og:url', content='http://marionettejs.com')
-    meta(property='og:description', content='Marionette simplifies your Backbone application code with robust views and architecture solutions.')
-    meta(property='og:see_also', content='https://github.com/marionettejs/backbone.marionette')
-    meta(property='og:title', content='The Backbone Framework')
-    meta(property='og:type', content='website')
+    block TwitterCard
+      meta(name='twitter:card', content='summary')
+      meta(name='twitter:creator', content='@marionettejs')
+      meta(name='twitter:description', content='Marionette simplifies your Backbone application code with robust views and architecture solutions.')
+      meta(name='twitter:image', content='http://marionettejs.com/images/marionette.png')
+      meta(name='twitter:site', content='@marionettejs')
+      meta(name='twitter:title', content='The Backbone Framework')
+    block OpenGraph
+      meta(property='og:site_name', content='Marionette.js')
+      meta(property='og:image', content='http://marionettejs.com/images/marionette.png')
+      meta(property='og:url', content='http://marionettejs.com')
+      meta(property='og:description', content='Marionette simplifies your Backbone application code with robust views and architecture solutions.')
+      meta(property='og:see_also', content='https://github.com/marionettejs/backbone.marionette')
+      meta(property='og:title', content='The Backbone Framework')
+      meta(property='og:type', content='website')
     //- Place favicon.ico in the root directory: see http://git.io/Ak0N
     link(rel='apple-touch-icon', href='images/apple-touch-icon.png')
     link(href='http://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css')
@@ -61,16 +64,19 @@ html(lang='en', itemscope, itemtype="http://schema.org/WebPage")
       include ../images/svg-sprite.svg
     block content
     script(src="//cdn.transifex.com/live.js" defer)
-    link(rel='stylesheet', href='/styles/marionette.css?t=#{Date.now()}')
-    script(src="/js/build.js?t=#{Date.now()}" defer)
-    script.
-      // Google Analytics
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    block styles
+      link(rel='stylesheet', href='/styles/marionette.css?t=#{Date.now()}')
+    block scripts
+      script(src="/js/build.js?t=#{Date.now()}" defer)
+    block GoogleAnalytics
+      script.
+        // Google Analytics
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      ga('create', 'UA-34606707-1', 'auto');
-      ga('create', 'UA-52639766-1', {'name':'MnCore'});
-      ga('send', 'pageview');
-      ga('MnCore.send', 'pageview');
+        ga('create', 'UA-34606707-1', 'auto');
+        ga('create', 'UA-52639766-1', {'name':'MnCore'});
+        ga('send', 'pageview');
+        ga('MnCore.send', 'pageview');


### PR DESCRIPTION
This PR adds basic blocks to web site main layout file to allow more flexible content authoring across pages:
- introduce blocks for main components of page: meta, title, TwitterCards,
OpenGraph, content, scripts, styles, GoogleAnalytics
- use different title and descriptions on downloads page to not hurt our web page
accessibility on the net

Using blocks will allows us to also use per-page specific styles/scripts to avoid problems like #302