### PR TITLE
Refactor footer section

### DIFF
--- a/src/download/sections/_package_info.jade
+++ b/src/download/sections/_package_info.jade
@@ -33,3 +33,5 @@ section.column-contain.hidden-xs#more-information
           a.notranslate(href= '/downloads/core/backbone.marionette.js') backbone.marionette.js
         li
           a.notranslate(href= '/downloads/core/backbone.marionette.min.js') backbone.marionette.min.js
+  .cl
+.cl

--- a/src/index.jade
+++ b/src/index.jade
@@ -14,4 +14,7 @@ block content
   include ./sections/_stickers
   include ./sections/_companies
 
-  include ./sections/_footer
+//- only home page has scroll to top in the footer
+block append footer
+  a(href="#top", class="top")
+    span.hidden-visually Top

--- a/src/layouts/layout.jade
+++ b/src/layouts/layout.jade
@@ -63,6 +63,8 @@ html(lang='en', itemscope, itemtype="http://schema.org/WebPage")
     div(style="display:none")
       include ../images/svg-sprite.svg
     block content
+    block footer
+      include ../sections/_footer
     script(src="//cdn.transifex.com/live.js" defer)
     block styles
       link(rel='stylesheet', href='/styles/marionette.css?t=#{Date.now()}')

--- a/src/sections/_companies.jade
+++ b/src/sections/_companies.jade
@@ -190,3 +190,4 @@ section.logos.column-contain.hidden-xs
       li
         a(href= "https://www.zweitag.de", target="_blank")
           img(data-src="images/logos/zweitag.png", alt= "zweitag")
+.cl

--- a/src/sections/_footer.jade
+++ b/src/sections/_footer.jade
@@ -4,6 +4,3 @@ footer
   p
     small Insights by 
       a.notranslate(href="//www.hotjar.com/?utm_source=badge", target="_blank") Hotjar
-
-  a(href="#top", class="top")
-    span.hidden-visually Top


### PR DESCRIPTION
This PR fixes one of standing our issues on download page:
* no footer
* bottom of page usage

- add footer block to main template
- change markup of bottom most sections to wrap correctly
- use footer on all pages based on main template

![20150227214215](https://cloud.githubusercontent.com/assets/14539/6420925/c0796b2c-beca-11e4-915f-6dc1d025c73a.jpg)
![20150227214235](https://cloud.githubusercontent.com/assets/14539/6420930/c3f5b76a-beca-11e4-817b-1cd65930657c.jpg)
