### PR TITLE
Add hot-fix for #283

### DIFF
--- a/src/stylesheets/_videos.scss
+++ b/src/stylesheets/_videos.scss
@@ -79,6 +79,14 @@
             height: 60px;
             cursor: pointer;
             color: #1F1F1F;
+            // hotfix for #283
+            background: {
+              image: linear-gradient(0deg, white, white);
+              position: center center;
+              repeat: no-repeat;
+              size: 50% 50%;
+            }
+
             &:hover{
               color: $red;
             }


### PR DESCRIPTION
This PR is a quick fix for #283 issue.

As filling shape is overoptimized and removed let's
add small background to fill the hole.

![20150228210936](https://cloud.githubusercontent.com/assets/14539/6427868/2ff7205c-bf8e-11e4-9068-eeff21443178.jpg)
Remove when #283 is fixed via npm update