### PR TITLE
Fix/small fixes

### DIFF
--- a/src/download/sections/_package_info.jade
+++ b/src/download/sections/_package_info.jade
@@ -1,37 +1,36 @@
 section.column-contain.hidden-xs#more-information
   h2.section-header Static Builds
-  .cl
+  div
+    .download-group
+      h3 Pre-Packaged
+      p These archives contain all of the files you need to get started with Marionette, including Backbone, jQuery and all other prerequisites.
+      p These packages include the standard UMD version of both the non-minified and minified versions of Marionette.
+      h4.h3 *nix (.tar.gz)
+      p
+        a.notranslate(href='/downloads/backbone.marionette.tar.gz') backbone.marionette.tar.gz
 
-  .download-group
-    h3 Pre-Packaged
-    p These archives contain all of the files you need to get started with Marionette, including Backbone, jQuery and all other prerequisites.
-    p These packages include the standard UMD version of both the non-minified and minified versions of Marionette.
-    h4.h3 *nix (.tar.gz)
-    p
-      a.notranslate(href='/downloads/backbone.marionette.tar.gz') backbone.marionette.tar.gz
-
-    h4.h3 Windows (.zip)
-    p
-      a.notranslate(href='/downloads/backbone.marionette.zip') backbone.marionette.zip
-  .download-group
-    h3 Bundled (UMD)
-    p Download the bundled backbone.marionette.js file with the Backbone.Wreqr and Backbone.BabySitter prerequisites built in.
-    .gw
-      ul.g
-        li
-          a.notranslate(href='/downloads/backbone.marionette.js') backbone.marionette.js
-        li
-          a.notranslate(href='/downloads/backbone.marionette.min.js') backbone.marionette.min.js
-  .download-group
-    h3 Core
-    p Download the core backbone.marionette.js file, without Backbone.BabySitter or Backbone.Wreqr.
-    p These pre-requisites are still required for Marionette to run, but this allows you to download them separately and update them independently.
-    h4.h3 Standard .js (UMD)
-    .gw
-      ul.g
-        li
-          a.notranslate(href= '/downloads/core/backbone.marionette.js') backbone.marionette.js
-        li
-          a.notranslate(href= '/downloads/core/backbone.marionette.min.js') backbone.marionette.min.js
+      h4.h3 Windows (.zip)
+      p
+        a.notranslate(href='/downloads/backbone.marionette.zip') backbone.marionette.zip
+    .download-group
+      h3 Bundled (UMD)
+      p Download the bundled backbone.marionette.js file with the Backbone.Wreqr and Backbone.BabySitter prerequisites built in.
+      .gw
+        ul.g
+          li
+            a.notranslate(href='/downloads/backbone.marionette.js') backbone.marionette.js
+          li
+            a.notranslate(href='/downloads/backbone.marionette.min.js') backbone.marionette.min.js
+    .download-group
+      h3 Core
+      p Download the core backbone.marionette.js file, without Backbone.BabySitter or Backbone.Wreqr.
+      p These pre-requisites are still required for Marionette to run, but this allows you to download them separately and update them independently.
+      h4.h3 Standard .js (UMD)
+      .gw
+        ul.g
+          li
+            a.notranslate(href= '/downloads/core/backbone.marionette.js') backbone.marionette.js
+          li
+            a.notranslate(href= '/downloads/core/backbone.marionette.min.js') backbone.marionette.min.js
   .cl
 .cl

--- a/src/stylesheets/_downloads.scss
+++ b/src/stylesheets/_downloads.scss
@@ -36,17 +36,17 @@
     }
   }
 
-  li {
+  li,
+  p {
     margin-bottom: 20px;
   }
 
   p {
     width:     85%;
-    font-size: $mid-font;
-    margin-bottom: 20px;
   }
 
-  a {
+  a,
+  p {
     font-size: $mid-font;
   }
 

--- a/src/stylesheets/_downloads.scss
+++ b/src/stylesheets/_downloads.scss
@@ -30,8 +30,10 @@
   width: 33.33%;
   @include below($med-breakpoint) {
     width: 100%;
-    border-bottom: 1px solid darken($light-blue, 4%);
     padding: 30px 0;
+    &:not(:last-child) {
+      border-bottom: 1px solid darken($light-blue, 4%);
+    }
   }
 
   li {
@@ -48,11 +50,6 @@
     font-size: $mid-font;
   }
 
-  &:nth-child(4) {
-    @include below($med-breakpoint) {
-      border: none;
-    }
-  }
 }
 
 small {

--- a/src/stylesheets/_downloads.scss
+++ b/src/stylesheets/_downloads.scss
@@ -57,6 +57,7 @@ small {
 }
 
 .download-section {
+  border-top: none;
   small {
     float: right;
     color: $gray;


### PR DESCRIPTION
A set of small fixes in downloads section:
- a rendering bug with bottom most group border
- a rendering bug with top most section top border
- shorten resulting css by different grouping of declarations:
```css
.download-group {
  float: left;
  width: 33.33%; }
  @media screen and (max-width: 768px) {
    .download-group {
      width: 100%;
      border-bottom: 1px solid #dfeaef;
      padding: 30px 0; } }
  .download-group li {
    margin-bottom: 20px; }
  .download-group p {
    width: 85%;
    font-size: 16px;
    margin-bottom: 20px; }
  .download-group a {
    font-size: 16px; }
  @media screen and (max-width: 768px) {
    .download-group:nth-child(4) {
      border: none; } }
```
```css
.download-group {
  float: left;
  width: 33.33%; }
  @media screen and (max-width: 768px) {
    .download-group {
      width: 100%;
      padding: 30px 0; }
      .download-group:not(:last-child) {
        border-bottom: 1px solid #dfeaef; } }
  .download-group li, .download-group p {
    margin-bottom: 20px; }
  .download-group p {
    width: 85%; }
  .download-group a, .download-group p {
    font-size: 16px; }
```