### PR TITLE
Fix flash of page content

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -27,18 +27,29 @@ module.exports = function(grunt) {
       }
     },
     critical: {
-        test: {
-            options: {
-                base: './',
-                css: [
-                    'dist/styles/marionette.css'
-                ],
-                width: 1200,
-                height: 800
-            },
-            src: 'dist/index.html',
-            dest: 'dist/index.html'
-        }
+      options: {
+        base: './',
+        width: 1200,
+        height: 800
+      },
+      home: {
+          options: {
+              css: [
+                  'dist/styles/marionette.css'
+              ]
+          },
+          src: 'dist/index.html',
+          dest: 'dist/index.html'
+      },
+      inspector: {
+          options: {
+            css: [
+              'dist/styles/inspector.css'
+            ]
+          },
+          src: 'dist/inspector/index.html',
+          dest: 'dist/inspector/index.html'
+      }
     },
     concat: {
       options: {

--- a/src/layouts/inspector-layout.jade
+++ b/src/layouts/inspector-layout.jade
@@ -10,7 +10,6 @@ html(lang='en')
     title Marionette Inspector
     link(rel='shortcut icon', href='images/favicon.ico', type='image/x-icon')
     link(rel='apple-touch-icon', href='images/apple-touch-icon.png')
-    link(href='http://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css')
     meta(content='Explore your Marionette App.', name='description')
     meta(name='viewport', content='width=device-width, initial-scale=1')
     meta(name='twitter:card', content='summary')
@@ -23,8 +22,11 @@ html(lang='en')
     meta(property='og:url', content='http://marionettejs.com')
     meta(property='og:title', content='The Marionette Inspector')
     meta(property='og:description', content="The inspector makes it possible to understand how your App works, without needing to understand how all the code works. This is possible because everything's one click away")
-    //- Place favicon.ico in the root directory: see http://git.io/Ak0N  
-    link(href='http://fonts.googleapis.com/css?family=Open+Sans', rel='stylesheet', type='text/css')
+    //- Place favicon.ico in the root directory: see http://git.io/Ak0N
+    block styles
+      link(rel='stylesheet', href='/styles/inspector.css?t=#{Date.now()}')
+      link(href='http://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css')
+      link(href='http://fonts.googleapis.com/css?family=Open+Sans', rel='stylesheet', type='text/css')
     // Hotjar
     script.
       (function (f, b) {
@@ -43,7 +45,6 @@ html(lang='en')
     block content
     div(style="display:none")
       include ../images/svg-sprite.svg
-    link(rel='stylesheet', href='/styles/inspector.css?t=#{Date.now()}')
     script.
       // Google Analytics
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/src/layouts/layout.jade
+++ b/src/layouts/layout.jade
@@ -37,8 +37,9 @@ html(lang='en', itemscope, itemtype="http://schema.org/WebPage")
       meta(property='og:type', content='website')
     //- Place favicon.ico in the root directory: see http://git.io/Ak0N
     link(rel='apple-touch-icon', href='images/apple-touch-icon.png')
-    link(href='http://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css')
-
+    block styles
+      link(rel='stylesheet', href='/styles/marionette.css?t=#{Date.now()}')
+      link(href='http://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css')
     // Hotjar
     script.
       (function (f, b) {
@@ -70,8 +71,6 @@ html(lang='en', itemscope, itemtype="http://schema.org/WebPage")
     block footer
       include ../sections/_footer
     script(src="//cdn.transifex.com/live.js" defer)
-    block styles
-      link(rel='stylesheet', href='/styles/marionette.css?t=#{Date.now()}')
     block scripts
       script(src="/js/build.js?t=#{Date.now()}" defer)
     block GoogleAnalytics


### PR DESCRIPTION
Move links to the header - the `grunt-critical` task will convert links
on the home page only - on other pages we still should keep links
to stylesheets in the header to avoid flash of unstyled content.
This probably is similar to what was already mentioned in #288 PR.
- all stylesheets in the same logic block
- all stylesheets in the same order in all templates

That's hard to catch this with LICE, as that flash is just a blink of seconds and I failed to capture it via Lice. Just try to reload Inspector page with cache disabled:
http://marionettejs.com/inspector

/cc @jdaudier 