### PR TITLE
Rename content row class. Closes #324

### DIFF
--- a/src/inspector/index.jade
+++ b/src/inspector/index.jade
@@ -26,7 +26,7 @@ block content
             li.max
         img(src="/images/inspector/inspector-preview.png")
     ul.features
-      ul.row
+      ul.grid-row
         li.feature-block
           h4 Understand
           p Understand how your app works without needing to understand how all the code works. &nbsp;
@@ -38,7 +38,7 @@ block content
         li.feature-block
           h4 Inspect
           p Inspect your view, UI, events, listener, models, attributes, and print them to the console as variables with one click!
-      ul.row.last
+      ul.grid-row.last
         li.feature-block
           h4 Explore
           p Explore your radio channels, requests, commands, and app with the Inspector glass.

--- a/src/stylesheets/inspector/index.scss
+++ b/src/stylesheets/inspector/index.scss
@@ -178,7 +178,8 @@ footer {
   margin-top: 165px;
 }
 
-.row {
+// [renamed] see #324
+.grid-row {
   overflow: hidden;
 
   &.last {


### PR DESCRIPTION
This PR renames a grid-row like named class used on Inspector landing page. See #324 for details why these rename is necessary.

This ad-hoc class seems to work as row of content in a grid - hence
current name is rewritten to be more explicit and fix
issue at the same time