### PR TITLE
Refactor/inspector headers

### DIFF
--- a/src/inspector/index.jade
+++ b/src/inspector/index.jade
@@ -29,25 +29,25 @@ block content
     div.features
       ul.grid-row
         li.feature-block
-          h4 Understand
+          h2.h4 Understand
           p Get an overview of how your app works without needing to understand all the code.&nbsp;
             a(href = "http://youtu.be/jbGm3mJXh_s", target= "_blank") See it in action
             | .
         li.feature-block
-          h4 Visualize
+          h2.h4 Visualize
           p See the view hierarchy with the UI tree along with app activity and history.
         li.feature-block
-          h4 Inspect
+          h2.h4 Inspect
           p Explore your views, UI, events, listeners, models, attributes, and print them to the console as variables with one click!
       ul.grid-row.last
         li.feature-block
-          h4 Explore
+          h2.h4 Explore
           p Use the handy Inspector glass to dive into your radio channels, requests, commands, and app.
         li.feature-block
-          h4 Jump
+          h2.h4 Jump
           p With intelligent linking, jump between elements of your app and the source in a snap.
         li.feature-block
-          h4 Customize
+          h2.h4 Customize
           p Curious how it works? Want to add a feature? The Inspector is developed in the open. Get involved!
   footer
     ul.footer-actions

--- a/src/inspector/index.jade
+++ b/src/inspector/index.jade
@@ -26,7 +26,7 @@ block content
             div.min
             div.max
         img(src="/images/inspector/inspector-preview.png", alt="Marionette Inspector tab active in the Google Chrome browser examining a TodoMVC application")
-    ul.features
+    div.features
       ul.grid-row
         li.feature-block
           h4 Understand

--- a/src/inspector/index.jade
+++ b/src/inspector/index.jade
@@ -65,5 +65,5 @@ block content
 
       li.etsy
         a(href="http://etsy.com", target= "_blank")
-          img.support-link-icon(src="/images/etsy-favicon.jpg" width="18" height="18")
+          img.support-link-icon(src="/images/etsy-favicon.jpg", width="18", height="18", alt="Etsy, Inc. logo")
           | Sponsored by Etsy!

--- a/src/stylesheets/pages/_inspector.scss
+++ b/src/stylesheets/pages/_inspector.scss
@@ -8,7 +8,8 @@ header {
   border-bottom: solid 1px #bad1e1;
 }
 
-h4 {
+h4,
+.h4 {
   font-size: 21px;
   margin-bottom: 20px;
   color: $red;


### PR DESCRIPTION
This PR brings another small changes to Inspector page clearing markup and text.

After this change and with new copy text the page is visible as:
![20150304223619](https://cloud.githubusercontent.com/assets/14539/6494302/f41d69b6-c2c0-11e4-9c03-8cdbf992e1c0.jpg)
has correct outline and can be easily read by software:
https://soundcloud.com/peter-blazejewicz/marionette-inspector

Thanks!