### PR TITLE
Remove link to unused font. Fixes #327

### DIFF
--- a/src/layouts/inspector-layout.jade
+++ b/src/layouts/inspector-layout.jade
@@ -26,7 +26,6 @@ html(lang='en', itemscope, itemtype="http://schema.org/WebApplication")
     link(rel='apple-touch-icon', href='images/apple-touch-icon.png')
     block styles
       link(rel='stylesheet', href='/styles/inspector.css?t=#{Date.now()}')
-      link(href='http://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css')
       link(href='http://fonts.googleapis.com/css?family=Open+Sans', rel='stylesheet', type='text/css')
     // Hotjar
     script.


### PR DESCRIPTION
The font is blocking resource, saved bytes for this one.
Though it could be already cached - but still counts as bug fix.
Questrial is used on all other pages.

The Firefox has builtin feature to list all fonts used on a web page - I used it to verify with a tool what already visible in used code.

Thanks!