### PR TITLE
YouTube button regression Fix/283 

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "grunt-contrib-imagemin": "0.9.2",
     "grunt-contrib-jade": "0.12.0",
     "grunt-contrib-watch": "0.6.1",
+    "grunt-critical": "^0.1.2",
     "grunt-docco": "0.3.3",
     "grunt-notify": "0.4.1",
     "grunt-postcss": "0.2.0",
@@ -54,7 +55,6 @@
     "marked": "0.3.2",
     "mkdirp": "0.5.0",
     "semver": "4.2.0",
-    "underscore": "1.6.0",
-    "grunt-critical": "~0.1.1"
+    "underscore": "1.6.0"
   }
 }

--- a/src/stylesheets/_videos.scss
+++ b/src/stylesheets/_videos.scss
@@ -79,14 +79,6 @@
             height: 60px;
             cursor: pointer;
             color: #1F1F1F;
-            // hotfix for #283
-            background: {
-              image: linear-gradient(0deg, white, white);
-              position: center center;
-              repeat: no-repeat;
-              size: 50% 50%;
-            }
-
             &:hover{
               color: $red;
             }


### PR DESCRIPTION
I'm no longer able to repeat locally problem with SVGs with updated `critical`/`grunt-critical`:
https://github.com/addyosmani/critical/releases/tag/v0.5.5
https://github.com/bezoerb/grunt-critical/releases/tag/v0.1.2
This PR reverts a patch fix for 283 and bumps `grunt-critical` requirements.

This PR should be verified by local PR test and fresh `npm install` and then `grunt compile-all`

@samccone I know you're busy :)

