### PR TITLE
Minify JavaScript source code

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -74,6 +74,26 @@ module.exports = function(grunt) {
       }
     },
 
+    uglify: {
+      options: {
+        compress: true,
+        mangle: false,
+        preserveComments: false,
+        screwIE8: true,
+        sourceMap: false
+      },
+      dist: {
+        files: {
+          'dist/js/build.js': ['<%= concat.dist.dest %>']
+        }
+      },
+      polyfills: {
+        files: {
+          'dist/js/classList.js': ['bower_components/html5-polyfills/classList.js']
+        }
+      }
+    },
+
     docco: {
       build: {
         src: ['backbone.marionette/lib/backbone.marionette.js'],
@@ -221,7 +241,7 @@ module.exports = function(grunt) {
       },
       scripts: {
         files: 'src/js/**/*',
-        tasks: ['notify:preHTML', 'concat', 'copy', 'notify:postHTML']
+        tasks: ['notify:preHTML', 'concat', 'uglify:polyfills', 'copy', 'notify:postHTML']
       },
       assets: {
         files: 'src/images/**/*',
@@ -331,6 +351,7 @@ module.exports = function(grunt) {
     'svgstore',
     'sass:dist',
     'concat',
+    'uglify',
     'copy',
     'imagemin',
     'compile-templates',

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "grunt-contrib-copy": "0.5.0",
     "grunt-contrib-imagemin": "0.9.2",
     "grunt-contrib-jade": "0.12.0",
+    "grunt-contrib-uglify": "^0.8.0",
     "grunt-contrib-watch": "0.6.1",
     "grunt-critical": "^0.1.2",
     "grunt-docco": "0.3.3",

--- a/src/sections/_nav.jade
+++ b/src/sections/_nav.jade
@@ -30,7 +30,7 @@ header.global-nav
 
 // Inline menu behavior since we want it to work right away regardless of network speed
 script
-  include ../../bower_components/html5-polyfills/classList.js
+  include ../../dist/js/classList.js
 
 script.
   var menu = document.getElementsByClassName('menu-icon')[0],


### PR DESCRIPTION
This PR takes care of minimising inlined polyfill code added with #344 and minimising concatenated website JavaScript code:

- add Grunt UglifyJS task dependency
- minify inlined JavaScript in development and production
- minify main source code in production only

Discussed here:
https://github.com/marionettejs/marionettejs.com/pull/344#issuecomment-77778438

The minimising inlined code is done both during development and built to not overcomplicate build phase:
![20150309212020](https://cloud.githubusercontent.com/assets/14539/6563609/be39ade2-c6a2-11e4-9f03-09ec0ebf5e87.jpg)

Thanks!

