### PR TITLE
Change/refactor markup in Docco custom template

### DIFF
--- a/src/docco/marionette.css
+++ b/src/docco/marionette.css
@@ -90,7 +90,7 @@ blockquote {
 
 ul.sections {
   list-style: none;
-  padding:0 0 5px 0;;
+  padding:0 0 5px 0;
   margin:0;
 }
 

--- a/src/docco/marionette.jst
+++ b/src/docco/marionette.jst
@@ -1,10 +1,10 @@
-<!DOCTYPE html>
-
-<html>
+<!doctype html>
+<html lang="en" itemscope itemtype="http://schema.org/WebPage">
 <head>
-  <title><%= title %></title>
-  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-  <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+  <meta charset="utf-8">
+  <meta name="x-ua-compatible" content="ie=edge">
+  <title itemprop="name"><%= title %></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" media="all" href="<%= css %>" />
 </head>
 <body>


### PR DESCRIPTION
Improve basic markup of Docco custom template
- modern tags
- some Schema.org
- all lowercase

Fix semicolon
Such silly code error raises warnings in Safari

Thanks!