### PR TITLE
Add versioned docco builds.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -94,17 +94,6 @@ module.exports = function(grunt) {
       }
     },
 
-    docco: {
-      build: {
-        src: ['backbone.marionette/lib/backbone.marionette.js'],
-        options: {
-          output: 'dist/annotated-src/',
-          template: 'src/docco/marionette.jst',
-          css: 'src/docco/marionette.css'
-        }
-      }
-    },
-
     clean: {
       dist: ['dist']
     },
@@ -339,7 +328,19 @@ module.exports = function(grunt) {
         src: 'src/api',
         dest: 'dist/api'
       }
-    }
+    },
+
+    compileAnnotatedSrc: {
+      marionette: {
+        options: {
+          repo: 'backbone.marionette',
+          src: 'backbone.marionette/lib/backbone.marionette.js',
+          template: 'src/docco/marionette.jst',
+          css: 'src/docco/marionette.css',
+          output: 'dist/annotated-src/'
+        }
+      }
+    },
   });
 
   grunt.registerTask('dev', [
@@ -378,9 +379,10 @@ module.exports = function(grunt) {
     'sass:dist'
   ]);
 
-  grunt.registerTask('compile-docco', [
-    'gitty:checkoutTag:marionette',
-    'docco:build'
+  grunt.registerTask('compile-annotated-src', [
+    'gitty:releaseTag',
+    'compileAnnotatedSrc',
+    'gitty:checkoutTag'
   ]);
 
   grunt.registerTask('compile-downloads', [
@@ -390,7 +392,7 @@ module.exports = function(grunt) {
   grunt.registerTask('compile-all', [
     'compile-site',
     'compile-docs',
-    'compile-docco',
+    'compile-annotated-src',
     'compile-downloads'
   ]);
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "dev": "grunt dev",
     "compile-docs": "grunt compile-docs",
     "compile-all": "grunt compile-all",
-    "compile-docco": "grunt compile-docco",
     "compile-downloads": "grunt compile-downloads",
     "deploy": "./ship.sh",
     "setup": "./setup.sh"
@@ -20,13 +19,14 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bower": "1.3.12",
     "compression": "1.0.8",
+    "docco": "^0.7.0",
     "express": "4.4.3",
+    "grunt-cli": "0.1.13",
     "morgan": "1.1.1",
     "mv": "2.0.3",
     "promisified-request": "0.0.3",
-    "grunt-cli": "0.1.13",
-    "bower": "1.3.12",
     "rimraf": "2.2.8"
   },
   "devDependencies": {
@@ -44,7 +44,6 @@
     "grunt-contrib-uglify": "^0.8.0",
     "grunt-contrib-watch": "0.6.1",
     "grunt-critical": "^0.1.2",
-    "grunt-docco": "0.3.3",
     "grunt-notify": "0.4.1",
     "grunt-postcss": "0.2.0",
     "grunt-sass": "0.17.0",

--- a/tasks/compile-annotated-src.js
+++ b/tasks/compile-annotated-src.js
@@ -1,0 +1,104 @@
+var Promise      = require('bluebird');
+var fs           = Promise.promisifyAll(require('fs'));
+var EventEmitter = require('events').EventEmitter;
+var _            = require('underscore');
+var path         = require('path');
+var gitty        = require('gitty');
+var validTags    = require('./utils/tags').valid;
+var docco        = require('docco');
+var GittyCache   = require('./utils/gitty-cache');
+
+var Compiler = function(options) {
+  _.extend(this, options);
+  this.repo = Promise.promisifyAll(gitty(this.repo));
+};
+
+Compiler.prototype = new EventEmitter();
+
+_.extend(Compiler.prototype, {
+  compile: function() {
+    return Promise.bind(this)
+      .then(this.setup)
+      .then(this.readFiles);
+  },
+
+  setup: function() {
+    return Promise.all([
+      GittyCache.getSortedTags(this.repo),
+      GittyCache.getReleaseTag(this.repo)
+    ]).bind(this).spread(function(tags, releaseTag) {
+      this.tags = tags;
+      this.releaseTag = releaseTag;
+    });
+  },
+
+  compileDocco: function(options) {
+    return new Promise(function(res, rej) {
+      docco.document(options, function(err) {
+        if (!err) {
+          res();
+        } else {
+          console.log("error building docco", err);
+          res();
+        }
+      });
+    })
+  },
+
+  readFiles: function() {
+    return Promise.bind(this).return(this.tags).map(function(tag) {
+      return this.repo.checkoutAsync(tag).bind(this).then(function() {
+        this.emit('checkoutTag', { tag: tag });
+        var output = this.output + tag + '/';
+        var src = this.src;
+        var options = {
+            args: [src],
+            output: output,
+            template: this.template,
+            css: this.css
+        };
+
+        return this.compileDocco(options)
+        .then(function() {
+          var oldPath = path.join(output, 'backbone.marionette.html')
+          var present = fs.existsSync(oldPath);
+
+          if (!present) return;
+
+          return fs.renameAsync(oldPath, path.join(output, 'index.html'));
+        })
+        .then(function() {
+          if (this.releaseTag != tag) return;
+
+          options.output = this.output;
+          return this.compileDocco(options);
+        }.bind(this));
+      });
+    }, { concurrency: 1 });
+  }
+});
+
+module.exports = function(grunt) {
+  grunt.registerMultiTask('compileAnnotatedSrc', function() {
+    var options   = this.options();
+
+    var compiler  = new Compiler({
+      repo     : path.resolve(options.repo),
+      src      : options.src,
+      output   : options.output,
+      css      : options.css,
+      template : options.template
+    });
+
+    compiler.on('checkoutTag', function(data) {
+      grunt.verbose.writeln('checkoutTag: ' + data.tag);
+    });
+
+    compiler.compile()
+    .then(function() {
+      compiler.removeAllListeners();
+      grunt.log.ok('Success!');
+    })
+    .then(this.async());
+  });
+};


### PR DESCRIPTION
:rocket: :rocket: :rocket: :rocket: 

------

With this people can now visit 

http://marionettejs.com/annotated-src/backbone.marionette/

http://marionettejs.com/annotated-src/v2.0.1/
http://marionettejs.com/annotated-src/v2.3.0/
http://marionettejs.com/annotated-src/v1.8.8/


This is a huge win for people using marionette, really excited to get this one in :clap: 