### PR TITLE
Add word-break for headers. Closes #362

### DIFF
--- a/src/docco/marionette.css
+++ b/src/docco/marionette.css
@@ -40,6 +40,12 @@ h1, h2, h3, h4, h5, h6 {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   text-transform: uppercase;
   margin: 30px 0 15px 0;
+  -ms-word-break: break-all;
+  word-break: break-all;
+  word-break: break-word;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  hyphens: auto;
 }
 
 h1 {


### PR DESCRIPTION
No easy fix for this one as we use long words for
object names (via dot notation).
The solution is based on similar problem from CSS Tricks:
http://goo.gl/EGJwGY