### PR TITLE
Improves seo metadata for api docs

### DIFF
--- a/src/docs/template.hbs
+++ b/src/docs/template.hbs
@@ -4,6 +4,22 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <title itemprop="name"><%- file.title %> - Marionette.js Documentation</title>
+    <meta name="description" content="<%= file.description %>" />
+
+    <meta property="og:title" content="<%- file.title %>" />
+    <meta property="og:site_name" content="Marionette.js" />
+    <meta property="og:description" content="<%= file.description %>" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="http://www.marionettejs.com/docs/<%- tag + '/' + file.basename %>.html" />
+    <meta property="og:image" content="http://marionettejs.com/images/marionette.png" />
+
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:creator" content="@marionettejs">
+    <meta name="twitter:description" content="<%- file.description %>">
+    <meta name="twitter:image" content="http://marionettejs.com/images/marionette.png">
+    <meta name="twitter:site" content="@marionettejs">
+    <meta name="twitter:title" content="<%- file.title %>">
+
     <link rel="stylesheet" href="../../styles/docs.css?t=<%- Date.now() %>">
     <!-- Place favicon.ico in the root directory: see http://git.io/Ak0N -->
     <link ref="apple-touch-icon" href="../../images/apple-touch-icon.png">

--- a/tasks/compile-docs.js
+++ b/tasks/compile-docs.js
@@ -103,6 +103,19 @@ _.extend(Compiler.prototype, {
     return pageTitle.charAt(0).toUpperCase() + pageTitle.slice(1);
   },
 
+    getPageDescription: function(compiledContents) {
+        // Blanket assumption that the first paragraph is
+        // suitable for a short description.
+        var description = compiledContents.match(/<p>([\s\S]*?)<\/p>/)[1];
+
+        return description
+            // force translation of breaks to a space
+            .replace(/<br>/g, ' ')
+            // remove remaining tags
+            .replace(/\<[^\>]*\>/g, '');
+//        }
+    },
+
   readFiles: function() {
     return Promise.bind(this).return(this.tags).map(function(tag) {
       return this.repo.checkoutAsync(tag).bind(this).then(function() {
@@ -120,6 +133,7 @@ _.extend(Compiler.prototype, {
           var compiled = this.compileContents(contents.toString());
           var basename = path.basename(filename, '.md');
           var title = this.getPageTitle(compiled);
+          var description = this.getPageDescription(compiled);
 
           this.emit('readFile', { file: src });
           return {
@@ -128,7 +142,8 @@ _.extend(Compiler.prototype, {
             filenane : filename,
             pathname : path.resolve(this.paths.tmp, tag),
             contents : compiled,
-            title    : title || basename
+            title    : title || basename,
+            description: description
           };
         });
       })


### PR DESCRIPTION
Grabs the first paragraph from the doc and uses that as a seo.description. Then fills out the usual open graph and twitter card details.

Tried to figure out howto get the date of the tag (to use for dc.created), but couldn't figure out a reliable process to put into gitty.