### PR TITLE
Fix url that causes redirects in OpenGraph

### DIFF
--- a/src/docs/template.hbs
+++ b/src/docs/template.hbs
@@ -10,7 +10,7 @@
     <meta property="og:site_name" content="Marionette.js" />
     <meta property="og:description" content="<%= file.description %>" />
     <meta property="og:type" content="article" />
-    <meta property="og:url" content="http://www.marionettejs.com/docs/<%- tag + '/' + file.basename %>.html" />
+    <meta property="og:url" content="http://marionettejs.com/docs/<%- tag + '/' + file.basename %>.html" />
     <meta property="og:image" content="http://marionettejs.com/images/marionette.png" />
 
     <meta name="twitter:card" content="summary">


### PR DESCRIPTION
This fixes url used in OpenGraph. They do not want redirects:
![20150311215533](https://cloud.githubusercontent.com/assets/14539/6606668/a65b0f8e-c839-11e4-9391-8a209f19dadf.jpg)
