### PR TITLE
Remove static image as per Twitter recomendation

### DIFF
--- a/src/docs/template.hbs
+++ b/src/docs/template.hbs
@@ -16,7 +16,6 @@
     <meta name="twitter:card" content="summary">
     <meta name="twitter:creator" content="@marionettejs">
     <meta name="twitter:description" content="<%- file.description %>">
-    <meta name="twitter:image" content="http://marionettejs.com/images/marionette.png">
     <meta name="twitter:site" content="@marionettejs">
     <meta name="twitter:title" content="<%- file.title %>">
 


### PR DESCRIPTION
As noted in #367 comment: https://github.com/marionettejs/marionettejs.com/pull/367#discussion_r26250677
Twitter recommends to not use the same image that could be reused across
multiple pages - like here with documentation pages.
Image is optional for this type of card
