### PR TITLE
Refactor/scripts

### DIFF
--- a/src/layouts/inspector-layout.jade
+++ b/src/layouts/inspector-layout.jade
@@ -37,5 +37,5 @@ html(lang='en', itemscope, itemtype="http://schema.org/WebApplication")
     div(style="display:none")
       include ../images/svg-sprite.svg
     block content
-    block GoogleAnalytics
+    block scripts
       include ../partials/_google_analytics

--- a/src/layouts/layout.jade
+++ b/src/layouts/layout.jade
@@ -55,6 +55,5 @@ html(lang='en', itemscope, itemtype="http://schema.org/WebPage")
     script(src="//cdn.transifex.com/live.js" defer)
     block scripts
       script(src="/js/build.js?t=#{Date.now()}" defer)
-    block GoogleAnalytics
       include ../partials/_google_analytics
 

--- a/src/layouts/layout.jade
+++ b/src/layouts/layout.jade
@@ -43,8 +43,6 @@ html(lang='en', itemscope, itemtype="http://schema.org/WebPage")
     block headerScripts
       // Hotjar
       include ../partials/_hotjar
-      // transifex
-      include ../partials/_transifex_config
   //- set this in page .jade file via vars
   body(class=bodyClass)
     div(style="display:none")
@@ -52,8 +50,10 @@ html(lang='en', itemscope, itemtype="http://schema.org/WebPage")
     block content
     block footer
       include ../sections/_footer
-    script(src="//cdn.transifex.com/live.js" defer)
     block scripts
+      // transifex
+      include ../partials/_transifex_config
+      script(src="//cdn.transifex.com/live.js" defer)
       script(src="/js/build.js?t=#{Date.now()}" defer)
       include ../partials/_google_analytics
 


### PR DESCRIPTION
This PR:
- simplifies page scripts in layouts - GA are now part of page scripts block
- move Transifex code into single position within page scripts block

body part of `layout.jade`:
```Jade
  body(class=bodyClass)
    div(style="display:none")
      include ../images/svg-sprite.svg
    block content
    block footer
      include ../sections/_footer
    block scripts
      // transifex
      include ../partials/_transifex_config
      script(src="//cdn.transifex.com/live.js" defer)
      script(src="/js/build.js?t=#{Date.now()}" defer)
      include ../partials/_google_analytics
```
body part of `layout-inspector`:
```Jade
  body(class=bodyClass)
    div(style="display:none")
      include ../images/svg-sprite.svg
    block content
    block scripts
      include ../partials/_google_analytics
```

GA was tested for regression with GA Chrome debugger extension.

Thanks!