### PR TITLE
Fix invalid urls in custom task

### DIFF
--- a/tasks/compile-downloads.sh
+++ b/tasks/compile-downloads.sh
@@ -18,11 +18,11 @@ curl -L https://raw.github.com/marionettejs/backbone.babysitter/master/lib/backb
 
 curl -L https://raw.github.com/marionettejs/backbone.marionette/master/lib/backbone.marionette.js > tmp/backbone.marionette/backbone.marionette.js
 curl -L https://raw.github.com/marionettejs/backbone.marionette/master/lib/backbone.marionette.min.js > tmp/backbone.marionette/backbone.marionette.min.js
-curl -L https://raw.github.com/marionettejs/backbone.marionette/master/lib/backbone.marionette.map > tmp/backbone.marionette/backbone.marionette.map
+curl -L https://raw.github.com/marionettejs/backbone.marionette/master/lib/backbone.marionette.min.js.map > tmp/backbone.marionette/backbone.marionette.min.js.map
 
 curl -L https://raw.github.com/marionettejs/backbone.marionette/master/lib/core/backbone.marionette.js > tmp/backbone.marionette/core/backbone.marionette.js
 curl -L https://raw.github.com/marionettejs/backbone.marionette/master/lib/core/backbone.marionette.min.js > tmp/backbone.marionette/core/backbone.marionette.min.js
-curl -L https://raw.github.com/marionettejs/backbone.marionette/master/lib/core/backbone.marionette.map > tmp/backbone.marionette/core/backbone.marionette.map
+curl -L https://raw.github.com/marionettejs/backbone.marionette/master/lib/core/backbone.marionette.min.js.map > tmp/backbone.marionette/core/backbone.marionette.min.js.map
 
 # Lets zip together in tar and zip formats
 tar -zcvf backbone.marionette.tar.gz tmp/backbone.marionette/


### PR DESCRIPTION
This fixes two invalid urls used in compile-download
custom task. I've found that when writing Npm Download based
version of the same task:

```
curl -i https://raw.github.com/marionettejs/backbone.marionette/master/lib/core/backbone.marionette.map
HTTP/1.1 301 Moved Permanently
Date: Sat, 14 Mar 2015 17:09:50 GMT
Server: Apache
Location: https://raw.githubusercontent.com/marionettejs/backbone.marionette/master/lib/core/backbone.marionette.map
Content-Length: 0
Accept-Ranges: bytes
Via: 1.1 varnish
Age: 0
X-Served-By: cache-fra1230-FRA
X-Cache: MISS
X-Cache-Hits: 0
Vary: Accept-Encoding
```
```
curl -i https://raw.github.com/marionettejs/backbone.marionette/master/lib/backbone.marionette.map
HTTP/1.1 301 Moved Permanently
Date: Sat, 14 Mar 2015 17:11:31 GMT
Server: Apache
Location: https://raw.githubusercontent.com/marionettejs/backbone.marionette/master/lib/backbone.marionette.map
Content-Length: 0
Accept-Ranges: bytes
Via: 1.1 varnish
Age: 0
X-Served-By: cache-fra1224-FRA
X-Cache: MISS
X-Cache-Hits: 0
Vary: Accept-Encoding
```

Thanks!