### PR TITLE
Add String method to strip <br> tags from markdown

### DIFF
--- a/tasks/compile-docs.js
+++ b/tasks/compile-docs.js
@@ -106,6 +106,7 @@ _.extend(Compiler.prototype, {
     getPageDescription: function(compiledContents) {
         // Blanket assumption that the first paragraph is
         // suitable for a short description.
+        // test
         var description = compiledContents.match(/<p>([\s\S]*?)<\/p>/)[1];
 
         return description


### PR DESCRIPTION
Currently, the docs are being compiled with the markdown parsing adding a `&lt;br&gt;` tag for every new line. This will have one of two effects. Either a) The docs are formatted with line breaks added for readability in the Markdown and the compiled HTML becomes cluttered with extraneous tags, and the layout styling is messed up, or b) The docs can be written without line breaks to preserve the intended page layout, but this creates long paragraphs, sacrificing readability.

That's not a choice we should have to make!

Excerpt of docs before this PR:

```html
<h2><a name="application-events" class="anchor" href="#application-events"><span class="header-link"></span></a>Application Events</h2>
<p>The <code>Application</code> object raises a few events during its lifecycle, using the
<br>
<a href="./marionette.functions.html#marionettetriggermethod">Marionette.triggerMethod</a> function. These events
<br>
can be used to do additional processing of your application. For example, you
<br>
may want to pre-process some data just before initialization happens. Or you may
<br>
want to wait until your entire application is initialized to start
<br>
<code>Backbone.history</code>.</p>
```

After:

```html
<h2>
  <a name="application-events" class="anchor" href="#application-events">
    <span class="header-link"></span>
  </a>
  Application Events
</h2>
<p>The <code>Application</code> object raises a few events during its lifecycle, using the
<a href="./marionette.functions.html">Marionette.triggerMethod</a>
function. These events can be used to do additional processing of your application.
For example, you may want to pre-process some data just before initialization happens.
Or you may want to wait until your entire application is initialized to start
<code>Backbone.history</code>.</p>
```

Closes #384.