### PR TITLE
Delete style that doesn’t solve inspector button not showing bug

### DIFF
--- a/src/stylesheets/pages/partials/_inspector.scss
+++ b/src/stylesheets/pages/partials/_inspector.scss
@@ -20,7 +20,6 @@
     }
 
     @include below($sm-breakpoint) {
-      display: inline-block;
       width: 85%;
       margin: 20px 0;
       &.secondary-color {


### PR DESCRIPTION
Inspector CTA buttons are not showing up on mobile and this line didn't solve it, so I'm removing it.

I'm using Chrome v41 on Samsung Galaxy S4 (Android 4.4.2)
![image](https://cloud.githubusercontent.com/assets/1666031/7058871/c0756498-de35-11e4-80c1-cc1863780639.png)
