### PR TITLE
Remove too general display block

### DIFF
--- a/src/stylesheets/components/_ui.scss
+++ b/src/stylesheets/components/_ui.scss
@@ -56,9 +56,6 @@ a.btn {
       text-align: center;
     }
 
-    @include below($sm-breakpoint) {
-      display: none;
-    }
   }
 
   &.secondary-color {


### PR DESCRIPTION
This specific declaration is so general, that it was hard to correctly
state when it is applied, how it was to be overriden and reversed.
For better use add existing helper-class  applied to
instance of component you want to hide

The problem covered by PR:
https://github.com/marionettejs/marionettejs.com/pull/396

cc/ @jdaudier 