### PR TITLE
Remove positioning class. Fixes #405

### DIFF
--- a/src/sections/_examples.jade
+++ b/src/sections/_examples.jade
@@ -1,7 +1,7 @@
 section.example-apps.column-contain
   h2 Example Apps
   .row
-    .example.col-4.left(itemscope, itemtype="http://schema.org/WebApplication")
+    .example.col-4(itemscope, itemtype="http://schema.org/WebApplication")
       header
         h3(itemprop="name") Marionette Wires
         link(itemprop="applicationCategory", href="http://schema.org/WebApplication")
@@ -24,7 +24,7 @@ section.example-apps.column-contain
       .btn-wrapper
         a.btn.btn-action(href="https://github.com/thejameskyle/marionette-wires", itemoprop="sameAs", target= "_blank") View Source
 
-    .example.col-4.left(itemscope, itemtype="http://schema.org/WebApplication")
+    .example.col-4(itemscope, itemtype="http://schema.org/WebApplication")
       header
         h3(itemprop="name") Gistbook
         link(itemprop="applicationCategory", href="http://schema.org/WebApplication")
@@ -43,7 +43,7 @@ section.example-apps.column-contain
       .btn-wrapper
         a.btn.btn-action(href="https://github.com/jmeas/gistbook", itemprop="sameAs", target= "_blank") View Source
 
-    .example.col-4.left(itemscope, itemtype="http://schema.org/WebApplication")
+    .example.col-4(itemscope, itemtype="http://schema.org/WebApplication")
       header
         h3(itemprop="name") Edit
         link(itemprop="applicationCategory", href="http://schema.org/WebApplication")


### PR DESCRIPTION
@jdaudier 
> I'm seeing this CSS discrepancy between production and local environment. I'm not sure why.

This one:
The .left class artefacts were left from older implementation
during rebasing (Jade :D) on 3 of 4 components

I've wrote meta tags when there were 3 components (3 examples). Then 4 arrived. So after merge I've rebased my PR with meta tags - but that's Jade and I haven't noticed during rebase that `.left` was removed and `.col-4` was extended.

Thanks!