### PR TITLE
Remove unnecessary padding in mast head

### DIFF
--- a/src/stylesheets/layout/_header.scss
+++ b/src/stylesheets/layout/_header.scss
@@ -10,7 +10,7 @@
 }
 
 .masthead {
-  padding:    0 $center_pad 40px;
+  padding:    0 $center_pad;
   overflow:   hidden;
   text-align: center;
   background: $light-blue;


### PR DESCRIPTION
Padding on the bottom of the masthead causes an unbalanced spacing.