### PR TITLE
Fix markup for rapid7 logo

### DIFF
--- a/src/sections/_companies.jade
+++ b/src/sections/_companies.jade
@@ -168,7 +168,7 @@ section.logos.column-contain.hidden-xs
           img(data-src="images/logos/railslove.png", alt= "Railslove", class="adjust")
       li
         a(href= "http://rapid7.com", target="_blank")
-        img(data-src="images/logos/rapid7.png", alt= "Rapid7", class="adjust")
+          img(data-src="images/logos/rapid7.png", alt= "Rapid7", class="adjust")
       li
         a(href= "http://ravenhq.com", target="_blank")
           img(data-src="images/logos/ravenhq.png", alt= "Raven HQt")


### PR DESCRIPTION
This PR allows for the Rapid7 logo to be clickable. A follow up fix to https://github.com/marionettejs/marionettejs.com/pull/363