### PR TITLE
Update examples - remove Gistbook link since it's no longer hosted

### DIFF
--- a/src/sections/_examples.jade
+++ b/src/sections/_examples.jade
@@ -28,8 +28,7 @@ section.example-apps.column-contain
       header
         h3(itemprop="name") Gistbook
         link(itemprop="applicationCategory", href="http://schema.org/WebApplication")
-        a.link(href="http://www.gistbook.io", itemprop="url", target= "_blank")
-          img(src="images/screenshots/gistbook.png", itemprop="screenshot", alt="Gistbook")
+        img(src="images/screenshots/gistbook.png", itemprop="screenshot", alt="Gistbook")
       p.description(itemprop="description").
         An app to write about technical subjects
       small.hidden-visually(itemprop="operatingSystem").


### PR DESCRIPTION
@peterblazejewicz @samccone @trezy 

<img width="917" alt="this" src="https://cloud.githubusercontent.com/assets/1666031/12069058/8399d044-afeb-11e5-8575-cf823d1feb20.png">
