### PR TITLE
:bug: Wrap all updates markup with custom class. Fixes #441

### DIFF
--- a/src/js/updates.js
+++ b/src/js/updates.js
@@ -52,7 +52,7 @@
     $('.changelog').html(changelogHtml);
 
     // Display code text in an elegant way.
-    $('.changelog code').addClass('code-wrap notranslate');
+    $('.changelog code, .part-two code').addClass('code-wrap notranslate');
 
   }).fail(function(err) {
     // Show ajax error.


### PR DESCRIPTION
Hi!
This commit adds missing selector to match also content
in markup that is originally hidden from users on updates
page.

Thanks!

/cc
@marionettejs/www 