### PR TITLE
Improve readability on updates page

### DIFF
--- a/src/stylesheets/pages/_updates.scss
+++ b/src/stylesheets/pages/_updates.scss
@@ -4,9 +4,11 @@
         margin-bottom: 20px;
     }
 
-    h4 {
+    h4, h5, h6 {
         margin-top: 15px;
         margin-bottom: 15px;
+        color: $red;
+        font-size: 16px;
     }
 
     ul {
@@ -16,6 +18,7 @@
             margin-left: 35px;
             font-size: 15px;
             color: $gray;
+            line-height: 1.25;
         }
     }
 
@@ -24,7 +27,11 @@
         color: $gray;
     }
     .code-wrap {
-        margin-bottom: 5px;
+        padding: 0.25em 0.5em;
+        margin-bottom: 0;
+        border-radius: 4px;
+        line-height: 1;
+        font-size: 15px;
         @media screen and (max-width:415px) {
             overflow-x: auto;
             max-width: 200px;


### PR DESCRIPTION
This commit changes rendering of markup by
adding small changes to styles on updates page:
- code tag styles
- headers (h4, h5, h6)
- consistent line-height and font-size
etc

before:
![20160318221442](https://cloud.githubusercontent.com/assets/14539/13892384/73ffc8a6-ed57-11e5-8253-3e5207020a12.jpg)

after:
![20160318221418](https://cloud.githubusercontent.com/assets/14539/13892386/7a0f0216-ed57-11e5-9cf4-42df4a821b92.jpg)


If used and found useful, it could be later refactored
to base style for consistent look within the page.

/cc
@jdaudier 

Thanks!