### PR TITLE
:bug: Enhance rendering of top bar markup. Fixes #444

### DIFF
--- a/src/js/search.js
+++ b/src/js/search.js
@@ -1,8 +1,10 @@
 // jshint maxstatements:20
 $(function() {
+  // on the startup remove inline style
+  $('.searchbar').css({display: ''});
+  //
   var $toggleCheckbox = $('#toggle-search');
   var $searchInput = $('#search-input');
-
   // Expand search
   // Toggle & focus the search bar when clicking on the magnifying glass.
   // This is achieved through a label and corresponding checkbox.

--- a/src/layouts/layout.jade
+++ b/src/layouts/layout.jade
@@ -54,9 +54,9 @@ html(lang='en', itemscope, itemtype="http://schema.org/WebPage")
     meta(name="msapplication-TileImage", content="/mstile-144x144.png")
     meta(name="theme-color", content="#ffffff")
     block styles
-      link(rel="stylesheet", href="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css")
       link(rel='stylesheet', href='/styles/marionette.css?t=#{Date.now()}')
       link(href='http://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css')
+      link(rel="stylesheet", href="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css")
     block headerScripts
       // Hotjar
       include ../partials/_hotjar

--- a/src/sections/_nav.jade
+++ b/src/sections/_nav.jade
@@ -12,7 +12,7 @@ header.global-nav
       svg(aria-hidden="true").search-icon
         use(xlink:href="#search-icon")
     nav.nav-slider.closed(role="navigation")
-      ul.nav-slider__list
+      ul.nav-slider__list(style="padding: 0; margin: 0")
         li.left
           a(itemprop="significantLink", href="/updates") Updates
           span.middot ·
@@ -39,7 +39,7 @@ header.global-nav
             span.hidden-visually Open search
             svg(aria-hidden="true").search-icon
               use(xlink:href="#search-icon")
-    .searchbar(role="search")
+    .searchbar(role="search", style="display: none;")
       .input-group
         label.hidden-visually(aria-label="Search", for="search-input") Search
         .search-input-wrapper

--- a/src/stylesheets/components/_search.scss
+++ b/src/stylesheets/components/_search.scss
@@ -18,7 +18,7 @@
   display: none;
   float: right;
   height: 40px;
-  width: 100%;
+  width: auto;
 
   @include below($large-breakpoint) {
     float: none;


### PR DESCRIPTION
This commit adds some little changes to markup to at
least partially fix #444:
- the critical task does not take into account hidden,
not rendered content - for this reason styling for search
input/bar are not added to critical CSS and unstyled content
impact rendering of top bar during page load. To elevate this
problem an inline style is added to .searchbar selector and
removed via JavaScript related code
- all *search* related assets are now loaded > after main assets
style import is moved and JS inclusion is moved as the content is
not required at all when page is started
- the embedded navbar styles are not applied by critical task. Inline
styling is added to UL element to remove default white space rendered
around top navigation to elevate rendering problem.

![image](https://cloud.githubusercontent.com/assets/14539/14191134/971fb244-f796-11e5-9ca6-3b6a3628584b.png)

Thanks!