### PR TITLE
add doc ordered files

### DIFF
--- a/tasks/consts.js
+++ b/tasks/consts.js
@@ -1,0 +1,16 @@
+module.exports = {
+  BLACKLIST_FILES: ['readme.md'],
+  TOPICS: [
+    'marionette.application.md',
+    'marionette.approuter.md',
+    'marionette.object.md',
+    'marionette.abstractview.md',
+    'marionette.view.md',
+    'marionette.itemview.md',
+    'marionette.collectionview.md',
+    'marionette.compositeview.md',
+    'marionette.layoutview.md',
+    'marionette.region.md',
+    'marionette.regionmanager.md'
+  ]
+};


### PR DESCRIPTION
I've added files order for doc.
```
    'marionette.application.md',
    'marionette.approuter.md',
    'marionette.object.md',
    'marionette.abstractview.md',
    'marionette.view.md',
    'marionette.itemview.md',
    'marionette.collectionview.md',
    'marionette.compositeview.md',
    'marionette.layoutview.md',
    'marionette.region.md',
    'marionette.regionmanager.md'
```

This files will be shown first, then other doc files. 
Also I added some improvements for order functionality.
@scott-w can you verify this order? Is it fine?