### PR TITLE
Build current docs version from master branch

### DIFF
--- a/src/docs/template.hbs
+++ b/src/docs/template.hbs
@@ -79,6 +79,14 @@
         </a>
         <div class="styled-select">
           <select id="version-dropdown">
+            <% if (file.tag == 'master') { %>
+              <option value="current" selected="selected">Current Version</option>
+            <% }  else { %>
+              <option value="current">Current Version</option>
+            <% } %>
+
+            <option value="" disabled>-----------------------</option>
+
             <% tags.forEach(function(tag) { %>
               <% if (file.tag == tag) { %>
                 <option value="<%- tag %>" selected="selected"><%- tag %></option>

--- a/tasks/compilers/additional-resources.js
+++ b/tasks/compilers/additional-resources.js
@@ -219,11 +219,14 @@ _.extend(Compiler.prototype, {
         });
       }).then(function(data) {
         var description = data.description || data.html_url;
-        return {
-          avatar_url: data.owner.avatar_url,
-          url: data.html_url,
-          description: description
-        };
+
+        if (data.owner) {
+          return {
+            avatar_url: data.owner.avatar_url,
+            url: data.html_url,
+            description: description
+          };
+        }
       });
     }.bind(this));
   },


### PR DESCRIPTION
Added "Current Version" to top of dropdown on docs page. This navigates to `/docs/current`. The current version of the docs will match the content of the docs on the `master` branch rather than linking to a specific version.

The advantage here is that we can release doc improvements without a GitHub release tag.

<img width="1428" alt="screen shot 2016-08-19 at 12 45 34" src="https://cloud.githubusercontent.com/assets/2510520/17808962/1091c22e-660b-11e6-95c4-29b6247cc809.png">
