### PR TITLE
Remove stray "tmp/" path from static build archives

### DIFF
--- a/tasks/compile-downloads.sh
+++ b/tasks/compile-downloads.sh
@@ -21,8 +21,10 @@ curl -L https://raw.github.com/marionettejs/backbone.marionette/master/lib/backb
 curl -L https://raw.github.com/marionettejs/backbone.marionette/master/lib/backbone.marionette.min.js.map > tmp/backbone.marionette/backbone.marionette.min.js.map
 
 # Lets zip together in tar and zip formats
-tar -zcvf backbone.marionette.tar.gz tmp/backbone.marionette/
-zip -r backbone.marionette.zip tmp/backbone.marionette/
+(cd tmp
+tar -zcvf ../backbone.marionette.tar.gz backbone.marionette/
+zip -r ../backbone.marionette.zip backbone.marionette/
+)
 
 # Move everything in place
 mv tmp/backbone.marionette/* dist/downloads


### PR DESCRIPTION
Static build archives (.zip and .tar.gz) are being generated with a stray "tmp/" prefix.

Here's a fix.