### PR TITLE
Performance improvements for start page

### DIFF
--- a/grunt/aliases.js
+++ b/grunt/aliases.js
@@ -53,8 +53,7 @@ module.exports = {
     'copy',
     'imagemin',
     'compile-templates',
-    'postcss:dist',
-    'critical'
+    'postcss:dist'
   ],
 
   'compile-templates': [

--- a/src/layouts/layout.jade
+++ b/src/layouts/layout.jade
@@ -55,8 +55,6 @@ html(lang='en', itemscope, itemtype="http://schema.org/WebPage")
     meta(name="theme-color", content="#ffffff")
     block styles
       link(rel='stylesheet', href='/styles/marionette.css?t=#{Date.now()}')
-      link(href='http://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css')
-      link(rel="stylesheet", href="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css")
     block headerScripts
       // Hotjar
       include ../partials/_hotjar

--- a/src/partials/_search.jade
+++ b/src/partials/_search.jade
@@ -1,7 +1,8 @@
-script(type="text/javascript", src="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js")
+script(type="text/javascript", src="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js" defer)
 script.
   docsearch({
     apiKey: '8bcc061269eccef1857658e85b62ebf7',
     indexName: 'marionettejs',
     inputSelector: '#search-input'
   });
+

--- a/src/sections/_footer.jade
+++ b/src/sections/_footer.jade
@@ -4,3 +4,7 @@ footer
   p
     small Insights by 
       a.notranslate(href="//www.hotjar.com/?utm_source=badge", target="_blank") Hotjar
+      
+  link(href='http://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css' media="bogus")
+  link(rel="stylesheet", href="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" media="bogus")
+    


### PR DESCRIPTION
**TL;DR;**

I noticed that our main page is loading in something strange way. Firstly loaded content with css but it all look broken, then loaded normal layout with fancy styles. I made some video to show it (it's with `regular 2g network`, to show it in 'slow motion')
https://monosnap.com/file/P5uuJQIVHXAsBzKnD3CTb7K5q9EbEY

I dig deeper and made some perf tests. So lets go.
First was analyzed `http://marionettejs.com/`

![marionette js the backbone framework 2016-10-22 15-16-58](https://cloud.githubusercontent.com/assets/6231516/19619459/c79b78b0-9870-11e6-9977-0c5f139ac3ce.png)

I cloned our site repo and run dev to debug why it is happening. I was really surprised that after running on dev it looks fine but different in scope of css loading.

![marionette js the backbone framework 2016-10-22 15-31-28](https://cloud.githubusercontent.com/assets/6231516/19619488/72043ab2-9871-11e6-800d-13d30aab49ea.png)

As you can see there are blocking css, rendering hasn't started because of it, hence no broken html.

I went deeper and run `compile-all` (this is grunt command which is running during deploying). And
![marionette js the backbone framework 2016-10-22 15-40-37](https://cloud.githubusercontent.com/assets/6231516/19619524/32f8ce86-9872-11e6-98fb-5925398172f6.png)

(it was run on 2G network because localhost to fast to show broken html)

So. dev and prod are different. And I got 3 questions.

**Why?** 

It's because we are using `grunt-critical` ONLY for prod.

---

**What to do?**

I propose to get rid of `grunt-critical` at all. Let main css be render blocking then we will not have any broken html which user see coming on our main page.

---

**What influence will it have on perf?**  

After adding missed `defer`, moving none critical css at the bottom and making main css be render blocking I got these results.
![marionette js the backbone framework 2016-10-22 15-12-42](https://cloud.githubusercontent.com/assets/6231516/19619605/1f74d83a-9874-11e6-8f64-36dd60c6f1df.png)

So now about perf. Unfortunately render blocking css is not so good and perf results...

I used fancy tool [pwmetrics](https://github.com/paulirish/pwmetrics).

**Current site**

![1 bash 2016-10-22 15-08-48](https://cloud.githubusercontent.com/assets/6231516/19619669/92db8b2e-9875-11e6-9b3e-1ef1c16c251a.png)

**Old dev results**

![1 bash 2016-10-22 15-35-13](https://cloud.githubusercontent.com/assets/6231516/19619681/cadc9ea0-9875-11e6-971a-1d83060fb4a3.png)

**New dev results**

![1 bash 2016-10-22 15-09-57](https://cloud.githubusercontent.com/assets/6231516/19619690/ee54c07e-9875-11e6-8058-68ec1d6b3304.png)

For prod I made double results...

**Old prod results** 

![1 bash 2016-10-22 15-45-26](https://cloud.githubusercontent.com/assets/6231516/19619699/0bba1254-9876-11e6-91a4-1b632a1738b2.png)

**New prod results**

![1 bash 2016-10-22 15-23-42](https://cloud.githubusercontent.com/assets/6231516/19619711/375448ee-9876-11e6-96eb-a9ed0cfff2c2.png)

So I think this perf results can be acceptable for better user experience...

P.S. I was inspired by @samccone and @paulirish [video](https://www.youtube.com/watch?v=6m_E-mC0y3Y)
