### PR TITLE
Update Marionette Wires URL

### DIFF
--- a/src/inspector/index.jade
+++ b/src/inspector/index.jade
@@ -42,7 +42,7 @@ block content
               use(xlink:href="#visualize-icon")
             | Visualize
           p See the view hierarchy with the UI tree along with app activity and history.&nbsp;
-            a(href = "http://www.marionettewires.com", target= "_blank") Try it out on a live app!
+            a(href = "https://marionette-wires.herokuapp.com", target= "_blank") Try it out on a live app!
         li.feature-block
           h2
             svg


### PR DESCRIPTION
`MarionetteWires.com` domain is expiring in on March 9th, so moving this to the native Heroku URL.

![image](https://cloud.githubusercontent.com/assets/1666031/23284018/2784cf5a-f9f7-11e6-9a27-8a18c7ca3e9d.png)
